### PR TITLE
ci(e2e): add repo-root workflow to run widget E2E on PRs

### DIFF
--- a/.github/workflows/widget-e2e.yml
+++ b/.github/workflows/widget-e2e.yml
@@ -22,25 +22,25 @@ jobs:
       PLAYWRIGHT_JUNIT_OUTPUT: test-results/junit-${{ matrix.os }}-shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}.xml
       PLAYWRIGHT_TRACES_DIR: traces/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}
       PLAYWRIGHT_VIDEO_DIR: test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}
-      PLAYWRIGHT_HTML_REPORT: playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}
+      PLAYWRIGHT_HTML_REPORT: playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node
+        PLAYWRIGHT_HTML_REPORT: playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: Install root deps
-        run: npm ci
+      - name: Install widget dependencies
+        run: npm ci --prefix widget --prefix widget
 
       - name: Cache Playwright binaries
         uses: actions/cache@v3
-        with:
+        - name: Install widget dependencies
           path: |
-            ~/.cache/ms-playwright
+          run: npm ci --prefix widget
             ~/Library/Caches/ms-playwright
             C:\\Users\\runneradmin\\AppData\\Local\\ms-playwright
           key: ${{ matrix.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
@@ -80,7 +80,7 @@ jobs:
             widget/playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
             widget/test-results/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
             traces/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
-            widget/test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
+            widget/test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
 
       - name: Upload Playwright Artifacts (always)
         if: always()
@@ -88,7 +88,7 @@ jobs:
         with:
           name: e2e-${{ matrix.os }}-shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}-${{ github.run_id }}-${{ github.sha }}
           path: |
-            widget/playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
-            widget/test-results/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
-            traces/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
-            widget/test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
+            widget/playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
+            widget/test-results/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
+            traces/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
+            widget/test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/

--- a/.github/workflows/widget-e2e.yml
+++ b/.github/workflows/widget-e2e.yml
@@ -1,0 +1,94 @@
+name: "Widget E2E Tests (root)"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch: {}
+
+jobs:
+  e2e:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [20]
+        shardIndex: [1, 2, 3]
+        totalShards: [3]
+    env:
+      SADIE_E2E: '1'
+      NODE_ENV: test
+      PLAYWRIGHT_JUNIT_OUTPUT: test-results/junit-${{ matrix.os }}-shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}.xml
+      PLAYWRIGHT_TRACES_DIR: traces/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}
+      PLAYWRIGHT_VIDEO_DIR: test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}
+      PLAYWRIGHT_HTML_REPORT: playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install root deps
+        run: npm ci
+
+      - name: Cache Playwright binaries
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            C:\\Users\\runneradmin\\AppData\\Local\\ms-playwright
+          key: ${{ matrix.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ matrix.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Prepare Playwright artifact directories
+        run: node -e "const fs=require('fs');[`playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}`,'test-results/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}',`traces/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}`,'test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}'].forEach(d=>{try{fs.mkdirSync(d,{recursive:true})}catch(e){}})"
+
+      - name: Build widget
+        run: npm run build --prefix widget
+
+      - name: Run E2E tests (sharded)
+        run: |
+          node -e "const { spawnSync } = require('child_process');
+          const cmd = 'npm';
+          const args = ['run','e2e','--prefix','widget','--silent','--','--shard=${{ matrix.shardIndex }}/${{ matrix.totalShards }}','--reporter=line','--reporter=junit=test-results/junit-${{ matrix.os }}-shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}.xml','--reporter=html=playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}','--trace=on-first-retry','--video=on-first-retry'];
+          let rc = 1;
+          for (let i = 0; i < 3; i++) {
+            console.log('Playwright attempt', i+1, 'of 3');
+            const r = spawnSync(cmd, args, { stdio: 'inherit' });
+            rc = r.status;
+            if (rc === 0) break;
+            if (i < 2) console.log('Attempt', i+1, 'failed — retrying...');
+          }
+          process.exit(rc);"
+
+      - name: Upload Playwright Artifacts (failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-${{ matrix.os }}-shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}-${{ github.run_id }}-${{ github.sha }}-failure
+          path: |
+            widget/playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
+            widget/test-results/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
+            traces/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}/
+            widget/test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
+
+      - name: Upload Playwright Artifacts (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-${{ matrix.os }}-shard-${{ matrix.shardIndex }}-of-${{ matrix.totalShards }}-${{ github.run_id }}-${{ github.sha }}
+          path: |
+            widget/playwright-report/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
+            widget/test-results/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
+            traces/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/
+            widget/test-results/videos/${{ matrix.os }}/shard-${{ matrix.shardIndex }}-of/${{ matrix.totalShards }}/


### PR DESCRIPTION
Adds a top-level GitHub Actions workflow that runs the widget E2E matrix (3 OS × 3 shards), caches Playwright, and uploads per-shard artifacts on both failure and always. This makes PR-level E2E checks visible and reusable across branches.