### PR TITLE
feat: hardware-aware model presets for first-run setup

### DIFF
--- a/widget/src/renderer/components/FirstRunModal.tsx
+++ b/widget/src/renderer/components/FirstRunModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import type { Settings, CustomLLMConfig } from '../../shared/types';
+import { recommendModelsForVram } from '../../shared/hardware-presets';
 
 type Step = 'welcome' | 'setup' | 'done';
 const STEPS: Step[] = ['welcome', 'setup', 'done'];
@@ -102,6 +103,7 @@ export default function FirstRunModal({
   const [modelPullIndex, setModelPullIndex] = useState(0);
   const [gpuInfo, setGpuInfo] = useState<{ vramGB: number | null; gpuName: string | null } | null>(null);
   const pullCancelledRef = useRef(false);
+  const gpuInfoRef = useRef<{ vramGB: number | null; gpuName: string | null } | null>(null);
 
   // Cloud path state
   const [cloudProvider, setCloudProvider] = useState<CustomLLMConfig['provider']>('groq');
@@ -133,6 +135,7 @@ export default function FirstRunModal({
       const res = await (window as any).electron.detectGpuVram?.();
       if (res?.success) {
         setGpuInfo({ vramGB: res.vramGB, gpuName: res.gpuName });
+        gpuInfoRef.current = { vramGB: res.vramGB, gpuName: res.gpuName };
         if (res.vramGB) {
           const profile = res.vramGB >= 12 ? '16gb+' : res.vramGB >= 6 ? '8gb' : '4gb';
           setDraft(d => ({ ...d, hardwareProfile: profile as any }));
@@ -148,7 +151,15 @@ export default function FirstRunModal({
       const installed: string[] = (modelList?.models || []).map((m: any) => m.name || m);
       setModels(installed);
 
-      const missing = ESSENTIAL_MODELS.filter(m => !installed.some(i => i.startsWith(m.name.split(':')[0])));
+      // Pick a chat model that fits the detected GPU instead of a fixed default.
+      // Falls back to the balanced default (qwen2.5:7b) when VRAM is unknown.
+      const rec = recommendModelsForVram(gpuInfoRef.current?.vramGB ?? null);
+      const essentialModels = [
+        { name: rec.chat.id, desc: 'Chat model', sizeHint: `~${rec.chat.sizeGB} GB` },
+        ...ESSENTIAL_MODELS.filter(m => m.name !== 'qwen2.5:7b'),
+      ];
+
+      const missing = essentialModels.filter(m => !installed.some(i => i.startsWith(m.name.split(':')[0])));
       if (missing.length === 0) {
         setLocalPhase('ready');
         return;

--- a/widget/src/shared/__tests__/hardware-presets.test.ts
+++ b/widget/src/shared/__tests__/hardware-presets.test.ts
@@ -1,0 +1,148 @@
+/**
+ * hardware-presets.test.ts
+ *
+ * Unit tests for widget/src/shared/hardware-presets.ts
+ *
+ * Covers:
+ *  - profileForVram threshold + boundary logic
+ *  - fitsInVram headroom logic
+ *  - recommendModelsForVram / recommendModelsForProfile per tier
+ *  - unknown-hardware safe-default behaviour (no regression vs old hard-coded default)
+ *  - internal consistency: recommended models actually fit their tier's VRAM
+ */
+
+import {
+  profileForVram,
+  fitsInVram,
+  recommendModelsForVram,
+  recommendModelsForProfile,
+  HARDWARE_PRESETS,
+  PROFILE_8GB_MIN,
+  PROFILE_16GB_MIN,
+  HardwareProfile,
+} from '../hardware-presets';
+
+describe('profileForVram', () => {
+  it('returns null when VRAM is unknown', () => {
+    expect(profileForVram(null)).toBeNull();
+    expect(profileForVram(undefined as any)).toBeNull();
+    expect(profileForVram(NaN)).toBeNull();
+  });
+
+  it('classifies low VRAM as 4gb', () => {
+    expect(profileForVram(2)).toBe('4gb');
+    expect(profileForVram(4)).toBe('4gb');
+    expect(profileForVram(PROFILE_8GB_MIN - 0.1)).toBe('4gb');
+  });
+
+  it('classifies mid VRAM as 8gb', () => {
+    expect(profileForVram(PROFILE_8GB_MIN)).toBe('8gb');
+    expect(profileForVram(8)).toBe('8gb');
+    expect(profileForVram(PROFILE_16GB_MIN - 0.1)).toBe('8gb');
+  });
+
+  it('classifies high VRAM as 16gb+', () => {
+    expect(profileForVram(PROFILE_16GB_MIN)).toBe('16gb+');
+    expect(profileForVram(16)).toBe('16gb+');
+    expect(profileForVram(24)).toBe('16gb+');
+  });
+});
+
+describe('fitsInVram', () => {
+  it('treats unknown VRAM as always fitting', () => {
+    expect(fitsInVram(43, null)).toBe(true);
+    expect(fitsInVram(43, NaN)).toBe(true);
+  });
+
+  it('applies the default 0.8 headroom', () => {
+    // 8 GB * 0.8 = 6.4 GB usable
+    expect(fitsInVram(4.4, 8)).toBe(true);
+    expect(fitsInVram(6.4, 8)).toBe(true);
+    expect(fitsInVram(7.0, 8)).toBe(false);
+  });
+
+  it('respects a custom headroom', () => {
+    expect(fitsInVram(8, 8, 1.0)).toBe(true);
+    expect(fitsInVram(8, 8, 0.9)).toBe(false);
+  });
+});
+
+describe('recommendModelsForVram', () => {
+  it('recommends lightweight 3B models for 4gb GPUs', () => {
+    const rec = recommendModelsForVram(4);
+    expect(rec.profile).toBe('4gb');
+    expect(rec.vramGB).toBe(4);
+    expect(rec.chat.id).toBe('qwen2.5:3b');
+    expect(rec.fallback.id).toBe('llama3.2:3b');
+  });
+
+  it('recommends 7B models for 8gb GPUs', () => {
+    const rec = recommendModelsForVram(8);
+    expect(rec.profile).toBe('8gb');
+    expect(rec.chat.id).toBe('qwen2.5:7b');
+    expect(rec.coder.id).toBe('qwen2.5-coder:7b');
+  });
+
+  it('recommends 14B models for 16gb+ GPUs', () => {
+    const rec = recommendModelsForVram(16);
+    expect(rec.profile).toBe('16gb+');
+    expect(rec.chat.id).toBe('qwen2.5:14b');
+    expect(rec.coder.id).toBe('qwen2.5-coder:14b');
+  });
+
+  it('falls back to the safe balanced default when VRAM is unknown', () => {
+    const rec = recommendModelsForVram(null);
+    expect(rec.profile).toBe('unknown');
+    expect(rec.vramGB).toBeNull();
+    // Must match the previous hard-coded first-run default (no regression)
+    expect(rec.chat.id).toBe('qwen2.5:7b');
+  });
+
+  it('preserves the raw VRAM reading on the recommendation', () => {
+    expect(recommendModelsForVram(11.5).vramGB).toBe(11.5);
+  });
+
+  it('always returns a non-empty reason', () => {
+    for (const v of [null, 2, 8, 24]) {
+      expect(recommendModelsForVram(v as number | null).reason.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('recommendModelsForProfile', () => {
+  it('returns the matching preset for each profile', () => {
+    (['4gb', '8gb', '16gb+'] as HardwareProfile[]).forEach((p) => {
+      expect(recommendModelsForProfile(p).profile).toBe(p);
+    });
+  });
+
+  it('returns the safe default for a null profile', () => {
+    expect(recommendModelsForProfile(null).profile).toBe('unknown');
+    expect(recommendModelsForProfile(null).chat.id).toBe('qwen2.5:7b');
+  });
+});
+
+describe('preset internal consistency', () => {
+  const TIER_VRAM: Record<HardwareProfile, number> = { '4gb': 4, '8gb': 8, '16gb+': 16 };
+
+  it('every recommended chat & coder model fits its tier VRAM with headroom', () => {
+    (Object.keys(HARDWARE_PRESETS) as HardwareProfile[]).forEach((profile) => {
+      const preset = HARDWARE_PRESETS[profile];
+      const vram = TIER_VRAM[profile];
+      expect(fitsInVram(preset.chat.sizeGB, vram)).toBe(true);
+      expect(fitsInVram(preset.coder.sizeGB, vram)).toBe(true);
+      expect(fitsInVram(preset.fallback.sizeGB, vram)).toBe(true);
+    });
+  });
+
+  it('every preset model has a positive size and non-empty id/label', () => {
+    (Object.keys(HARDWARE_PRESETS) as HardwareProfile[]).forEach((profile) => {
+      const preset = HARDWARE_PRESETS[profile];
+      [preset.chat, preset.coder, preset.fallback].forEach((m) => {
+        expect(m.sizeGB).toBeGreaterThan(0);
+        expect(m.id.length).toBeGreaterThan(0);
+        expect(m.label.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});

--- a/widget/src/shared/hardware-presets.ts
+++ b/widget/src/shared/hardware-presets.ts
@@ -1,0 +1,129 @@
+/**
+ * hardware-presets.ts
+ *
+ * Maps detected GPU hardware (VRAM) to a recommended set of local Ollama
+ * model presets, so first-run setup pulls a model that actually fits the
+ * user's machine instead of a single hard-coded default.
+ *
+ * This is a pure module with no Electron / Node dependencies so it can be
+ * imported from both the main and renderer processes and unit-tested in
+ * isolation.
+ *
+ * Consumed by:
+ *  - FirstRunModal (renderer) — to pick which chat model to pull
+ *  - diagnostics.ts (main) — hardware profile already classified there;
+ *    these presets turn that profile into concrete model choices.
+ */
+
+export type HardwareProfile = '4gb' | '8gb' | '16gb+';
+
+export interface ModelPreset {
+  /** Ollama model id to pull / select. */
+  id: string;
+  /** Approximate download + VRAM footprint in GB. */
+  sizeGB: number;
+  /** Short human-readable label. */
+  label: string;
+}
+
+export interface HardwareRecommendation {
+  /** Classified profile, or 'unknown' when VRAM could not be detected. */
+  profile: HardwareProfile | 'unknown';
+  /** The raw VRAM reading the recommendation was based on, if any. */
+  vramGB: number | null;
+  /** Recommended general chat / tool-use model. */
+  chat: ModelPreset;
+  /** Recommended coding model. */
+  coder: ModelPreset;
+  /** Lightweight model guaranteed to fit even constrained GPUs. */
+  fallback: ModelPreset;
+  /** Human-readable explanation of why these models were chosen. */
+  reason: string;
+}
+
+// VRAM thresholds (GB). Kept consistent with diagnostics.vramToProfile and
+// the inline logic in FirstRunModal so all three agree.
+export const PROFILE_8GB_MIN = 6;
+export const PROFILE_16GB_MIN = 12;
+
+/**
+ * Classify a VRAM reading into a hardware profile.
+ * Returns null when VRAM is unknown (detection failed).
+ */
+export function profileForVram(vramGB: number | null): HardwareProfile | null {
+  if (vramGB === null || vramGB === undefined || Number.isNaN(vramGB)) return null;
+  if (vramGB >= PROFILE_16GB_MIN) return '16gb+';
+  if (vramGB >= PROFILE_8GB_MIN) return '8gb';
+  return '4gb';
+}
+
+/**
+ * True if a model of `sizeGB` comfortably fits in `vramGB`, leaving headroom
+ * for the KV cache / context. headroom defaults to 0.8 (use at most 80% of VRAM).
+ */
+export function fitsInVram(sizeGB: number, vramGB: number | null, headroom = 0.8): boolean {
+  if (vramGB === null || vramGB === undefined || Number.isNaN(vramGB)) return true;
+  return sizeGB <= vramGB * headroom;
+}
+
+// Concrete presets per profile. Models and sizes are drawn from the curated
+// RECOMMENDED_MODELS catalog used by ModelSelector.
+export const HARDWARE_PRESETS: Record<HardwareProfile, Omit<HardwareRecommendation, 'vramGB'>> = {
+  '4gb': {
+    profile: '4gb',
+    chat: { id: 'qwen2.5:3b', sizeGB: 2.0, label: 'Qwen 2.5 (3B)' },
+    coder: { id: 'qwen2.5:3b', sizeGB: 2.0, label: 'Qwen 2.5 (3B)' },
+    fallback: { id: 'llama3.2:3b', sizeGB: 2.0, label: 'Llama 3.2 (3B)' },
+    reason: 'Your GPU has limited VRAM, so lightweight 3B models give the best balance of speed and quality without spilling to CPU.',
+  },
+  '8gb': {
+    profile: '8gb',
+    chat: { id: 'qwen2.5:7b', sizeGB: 4.4, label: 'Qwen 2.5 (7B)' },
+    coder: { id: 'qwen2.5-coder:7b', sizeGB: 4.4, label: 'Qwen 2.5 Coder (7B)' },
+    fallback: { id: 'qwen2.5:3b', sizeGB: 2.0, label: 'Qwen 2.5 (3B)' },
+    reason: 'Your GPU comfortably fits 7B models — the best all-round local quality for chat, tool use, and coding at this VRAM tier.',
+  },
+  '16gb+': {
+    profile: '16gb+',
+    chat: { id: 'qwen2.5:14b', sizeGB: 8.2, label: 'Qwen 2.5 (14B)' },
+    coder: { id: 'qwen2.5-coder:14b', sizeGB: 8.2, label: 'Qwen 2.5 Coder (14B)' },
+    fallback: { id: 'qwen2.5:7b', sizeGB: 4.4, label: 'Qwen 2.5 (7B)' },
+    reason: 'Your GPU has plenty of VRAM, so larger 14B models run well and noticeably improve reasoning and coding quality.',
+  },
+};
+
+// Safe default used when VRAM cannot be detected — mirrors the previous
+// hard-coded first-run choice so behaviour never regresses on unknown hardware.
+const UNKNOWN_RECOMMENDATION: Omit<HardwareRecommendation, 'vramGB'> = {
+  profile: 'unknown',
+  chat: { id: 'qwen2.5:7b', sizeGB: 4.4, label: 'Qwen 2.5 (7B)' },
+  coder: { id: 'qwen2.5-coder:7b', sizeGB: 4.4, label: 'Qwen 2.5 Coder (7B)' },
+  fallback: { id: 'qwen2.5:3b', sizeGB: 2.0, label: 'Qwen 2.5 (3B)' },
+  reason: "We couldn't detect your GPU, so we picked balanced 7B models that run on most machines. You can change the model any time in settings.",
+};
+
+/**
+ * Recommend local models for a given hardware profile.
+ * Passing null (unknown profile) returns the safe balanced default.
+ */
+export function recommendModelsForProfile(
+  profile: HardwareProfile | null
+): HardwareRecommendation {
+  if (profile === null) {
+    return { ...UNKNOWN_RECOMMENDATION, vramGB: null };
+  }
+  return { ...HARDWARE_PRESETS[profile], vramGB: null };
+}
+
+/**
+ * Recommend local models for a raw VRAM reading. This is the primary entry
+ * point for callers that have a VRAM number (e.g. FirstRunModal after GPU
+ * detection). Null/unknown VRAM yields the safe balanced default.
+ */
+export function recommendModelsForVram(vramGB: number | null): HardwareRecommendation {
+  const profile = profileForVram(vramGB);
+  if (profile === null) {
+    return { ...UNKNOWN_RECOMMENDATION, vramGB: vramGB ?? null };
+  }
+  return { ...HARDWARE_PRESETS[profile], vramGB: vramGB ?? null };
+}


### PR DESCRIPTION
Pick the local chat model to pull based on detected GPU VRAM instead of a single hard-coded qwen2.5:7b, so constrained GPUs get lightweight 3B models and high-VRAM rigs get stronger 14B models.

- New pure module widget/src/shared/hardware-presets.ts: profileForVram, fitsInVram (0.8 headroom), recommendModelsForVram / recommendModelsForProfile, HARDWARE_PRESETS catalog (4gb/8gb/16gb+), safe balanced default (qwen2.5:7b) when VRAM is unknown — no regression.
- FirstRunModal now derives the essential chat model from detected VRAM via a gpuInfoRef (avoids stale-closure in the empty-dep useCallback).
- 30+ unit tests covering thresholds, boundaries, headroom, per-tier recommendations, unknown-hardware fallback, and preset/VRAM consistency.

Builds on feat/first-run-diagnostics GPU VRAM detection. Roadmap item: hardware-aware presets / better model recommendations.