### PR TITLE
feat: first-run diagnostics — disk, ports, permissions, GPU

### DIFF
--- a/widget/src/main/__tests__/diagnostics.test.ts
+++ b/widget/src/main/__tests__/diagnostics.test.ts
@@ -1,0 +1,277 @@
+/**
+ * diagnostics.test.ts
+ *
+ * Unit tests for widget/src/main/diagnostics.ts
+ *
+ * Covers:
+ *  - buildDiskInfo threshold logic
+ *  - checkService (mocked axios)
+ *  - checkWritePermissions (real temp dir)
+ *  - vramToProfile mapping
+ *  - runDiagnostics integration (all external calls mocked)
+ */
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('axios');
+jest.mock('../moa', () => ({
+  detectGpuVram: jest.fn(),
+}));
+jest.mock('electron', () => ({
+  app: {
+    getPath: jest.fn(() => '/mock/userData'),
+    on: jest.fn(),
+    isPackaged: false,
+  },
+  ipcMain: { handle: jest.fn(), on: jest.fn() },
+  BrowserWindow: jest.fn(),
+}));
+
+import axios from 'axios';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  buildDiskInfo,
+  checkService,
+  checkWritePermissions,
+  vramToProfile,
+  runDiagnostics,
+  DISK_WARN_GB,
+  DISK_BLOCK_GB,
+} from '../diagnostics';
+import { detectGpuVram } from '../moa';
+
+// ── buildDiskInfo ─────────────────────────────────────────────────────────────
+
+describe('buildDiskInfo', () => {
+  test('returns ok=true and no warning when null (detection unavailable)', () => {
+    const result = buildDiskInfo(null);
+    expect(result.ok).toBe(true);
+    expect(result.warning).toBeNull();
+    expect(result.freeGB).toBeNull();
+  });
+
+  test('returns ok=false and blocking warning when below DISK_BLOCK_GB', () => {
+    const result = buildDiskInfo(DISK_BLOCK_GB - 0.5);
+    expect(result.ok).toBe(false);
+    expect(result.warning).toContain('free up space');
+  });
+
+  test('returns ok=true and a soft warning between DISK_BLOCK_GB and DISK_WARN_GB', () => {
+    const result = buildDiskInfo((DISK_BLOCK_GB + DISK_WARN_GB) / 2);
+    expect(result.ok).toBe(true);
+    expect(result.warning).not.toBeNull();
+    expect(result.warning).toContain('GB free');
+  });
+
+  test('returns ok=true and no warning above DISK_WARN_GB', () => {
+    const result = buildDiskInfo(DISK_WARN_GB + 5);
+    expect(result.ok).toBe(true);
+    expect(result.warning).toBeNull();
+  });
+
+  test('exact boundary: DISK_BLOCK_GB should block', () => {
+    const result = buildDiskInfo(DISK_BLOCK_GB - 0.01);
+    expect(result.ok).toBe(false);
+  });
+
+  test('exact boundary: DISK_WARN_GB should be clear', () => {
+    const result = buildDiskInfo(DISK_WARN_GB);
+    expect(result.ok).toBe(true);
+    expect(result.warning).toBeNull();
+  });
+});
+
+// ── vramToProfile ─────────────────────────────────────────────────────────────
+
+describe('vramToProfile', () => {
+  test('returns null when vramGB is null', () => {
+    expect(vramToProfile(null)).toBeNull();
+  });
+
+  test('4gb for low VRAM', () => {
+    expect(vramToProfile(4)).toBe('4gb');
+    expect(vramToProfile(5.9)).toBe('4gb');
+  });
+
+  test('8gb for mid VRAM', () => {
+    expect(vramToProfile(6)).toBe('8gb');
+    expect(vramToProfile(11.9)).toBe('8gb');
+  });
+
+  test('16gb+ for high VRAM', () => {
+    expect(vramToProfile(12)).toBe('16gb+');
+    expect(vramToProfile(24)).toBe('16gb+');
+  });
+});
+
+// ── checkService ──────────────────────────────────────────────────────────────
+
+describe('checkService', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('returns reachable=true for a 200 response', async () => {
+    (axios.get as jest.Mock).mockResolvedValueOnce({ status: 200 });
+    const result = await checkService('http://localhost:11434/api/tags');
+    expect(result.reachable).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(typeof result.latencyMs).toBe('number');
+  });
+
+  test('returns reachable=false on network error (ECONNREFUSED)', async () => {
+    (axios.get as jest.Mock).mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+    const result = await checkService('http://localhost:11434/api/tags');
+    expect(result.reachable).toBe(false);
+    expect(result.statusCode).toBeNull();
+    expect(result.latencyMs).toBeNull();
+  });
+
+  test('returns reachable=false for 5xx response', async () => {
+    (axios.get as jest.Mock).mockResolvedValueOnce({ status: 503 });
+    const result = await checkService('http://localhost:5678/healthz');
+    expect(result.reachable).toBe(false);
+    expect(result.statusCode).toBe(503);
+  });
+
+  test('returns reachable=true for 404 (service up but path unknown)', async () => {
+    (axios.get as jest.Mock).mockResolvedValueOnce({ status: 404 });
+    const result = await checkService('http://localhost:6333/healthz');
+    expect(result.reachable).toBe(true);
+    expect(result.statusCode).toBe(404);
+  });
+});
+
+// ── checkWritePermissions ─────────────────────────────────────────────────────
+
+describe('checkWritePermissions', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homebot-diag-test-'));
+  });
+
+  afterAll(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test('returns canWrite=true for a writable directory', () => {
+    const result = checkWritePermissions(tmpDir);
+    expect(result.canWrite).toBe(true);
+    expect(result.path).toBe(tmpDir);
+  });
+
+  test('returns canWrite=false for a non-existent uncreateable path', () => {
+    // On a real system /proc/no-such-dir is unwritable on Linux; use a mock for portability
+    const fsMock = jest.spyOn(fs, 'mkdirSync').mockImplementationOnce(() => { throw new Error('EPERM'); });
+    const existsMock = jest.spyOn(fs, 'existsSync').mockReturnValueOnce(false);
+    const result = checkWritePermissions('/proc/no-write-access');
+    expect(result.canWrite).toBe(false);
+    fsMock.mockRestore();
+    existsMock.mockRestore();
+  });
+});
+
+// ── runDiagnostics integration ────────────────────────────────────────────────
+
+describe('runDiagnostics', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homebot-diag-int-'));
+  });
+
+  afterAll(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  beforeEach(() => {
+    // Default: Ollama online, n8n offline, Qdrant offline, GPU known
+    (axios.get as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/tags')) return Promise.resolve({ status: 200 });
+      return Promise.reject(new Error('ECONNREFUSED'));
+    });
+    (detectGpuVram as jest.Mock).mockResolvedValue({ vramGB: 8, gpuName: 'RTX 3070', method: 'nvidia-smi' });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  test('returns a complete DiagnosticsResult', async () => {
+    const result = await runDiagnostics(
+      { ollamaUrl: 'http://127.0.0.1:11434', n8nUrl: 'http://localhost:5678' },
+      tmpDir
+    );
+
+    expect(result).toHaveProperty('disk');
+    expect(result).toHaveProperty('ollama');
+    expect(result).toHaveProperty('n8n');
+    expect(result).toHaveProperty('qdrant');
+    expect(result).toHaveProperty('permissions');
+    expect(result).toHaveProperty('hardware');
+    expect(result).toHaveProperty('durationMs');
+    expect(result).toHaveProperty('timestamp');
+  });
+
+  test('Ollama reachable, n8n and Qdrant not', async () => {
+    const result = await runDiagnostics(
+      { ollamaUrl: 'http://127.0.0.1:11434', n8nUrl: 'http://localhost:5678' },
+      tmpDir
+    );
+    expect(result.ollama.reachable).toBe(true);
+    expect(result.n8n.reachable).toBe(false);
+    expect(result.qdrant.reachable).toBe(false);
+  });
+
+  test('hardware profile is set from GPU detection', async () => {
+    const result = await runDiagnostics(
+      { ollamaUrl: 'http://127.0.0.1:11434', n8nUrl: 'http://localhost:5678' },
+      tmpDir
+    );
+    expect(result.hardware.vramGB).toBe(8);
+    expect(result.hardware.gpuName).toBe('RTX 3070');
+    expect(result.hardware.profile).toBe('8gb');
+  });
+
+  test('permissions.canWrite=true for a real writable temp dir', async () => {
+    const result = await runDiagnostics(
+      { ollamaUrl: 'http://127.0.0.1:11434', n8nUrl: 'http://localhost:5678' },
+      tmpDir
+    );
+    expect(result.permissions.canWrite).toBe(true);
+  });
+
+  test('survives GPU detection failure gracefully', async () => {
+    (detectGpuVram as jest.Mock).mockRejectedValueOnce(new Error('nvidia-smi not found'));
+    const result = await runDiagnostics(
+      { ollamaUrl: 'http://127.0.0.1:11434', n8nUrl: 'http://localhost:5678' },
+      tmpDir
+    );
+    expect(result.hardware.vramGB).toBeNull();
+    expect(result.hardware.profile).toBeNull();
+  });
+
+  test('durationMs is a positive number', async () => {
+    const result = await runDiagnostics(
+      { ollamaUrl: 'http://127.0.0.1:11434', n8nUrl: 'http://localhost:5678' },
+      tmpDir
+    );
+    expect(result.durationMs).toBeGreaterThan(0);
+  });
+
+  test('timestamp is a valid ISO string', async () => {
+    const result = await runDiagnostics(
+      { ollamaUrl: 'http://127.0.0.1:11434', n8nUrl: 'http://localhost:5678' },
+      tmpDir
+    );
+    expect(() => new Date(result.timestamp)).not.toThrow();
+    expect(new Date(result.timestamp).getTime()).toBeGreaterThan(0);
+  });
+
+  test('custom qdrantUrl is used', async () => {
+    const result = await runDiagnostics(
+      { ollamaUrl: 'http://127.0.0.1:11434', n8nUrl: 'http://localhost:5678', qdrantUrl: 'http://localhost:6333' },
+      tmpDir
+    );
+    expect(result.qdrant.url).toContain('6333');
+  });
+});

--- a/widget/src/main/diagnostics.ts
+++ b/widget/src/main/diagnostics.ts
@@ -1,0 +1,203 @@
+/**
+ * diagnostics.ts
+ *
+ * Runs a comprehensive set of first-run (and on-demand) checks in parallel:
+ *  - Disk space: is there enough free space to pull models?
+ *  - Service reachability: Ollama, n8n, Qdrant
+ *  - Write permissions: can we write to the userData directory?
+ *  - Hardware: GPU VRAM + recommended hardware profile
+ *
+ * Used by the `homebot:run-diagnostics` IPC channel (ipc-handlers.ts) and
+ * by the FirstRunModal to warn before starting a model pull.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import axios from 'axios';
+import { detectGpuVram } from './moa';
+
+// Minimum free disk GB before showing a warning
+export const DISK_WARN_GB = 10;
+// Minimum free disk GB before blocking a model pull
+export const DISK_BLOCK_GB = 4;
+
+export interface DiskInfo {
+  /** Available space in GB on the drive containing userData, or null if detection failed. */
+  freeGB: number | null;
+  /** True if there is enough disk space to safely pull models. */
+  ok: boolean;
+  /** Human-readable warning, or null when all is fine. */
+  warning: string | null;
+}
+
+export interface ServiceStatus {
+  reachable: boolean;
+  url: string;
+  /** HTTP status code if the service responded, or null on network error. */
+  statusCode: number | null;
+  latencyMs: number | null;
+}
+
+export interface PermissionsInfo {
+  /** True if the app can write to its userData directory. */
+  canWrite: boolean;
+  /** The path that was tested. */
+  path: string;
+}
+
+export interface HardwareInfo {
+  vramGB: number | null;
+  gpuName: string | null;
+  /** '4gb' | '8gb' | '16gb+' | null (if detection failed) */
+  profile: '4gb' | '8gb' | '16gb+' | null;
+}
+
+export interface DiagnosticsResult {
+  disk: DiskInfo;
+  ollama: ServiceStatus;
+  n8n: ServiceStatus;
+  qdrant: ServiceStatus;
+  permissions: PermissionsInfo;
+  hardware: HardwareInfo;
+  /** Wall-clock time for the full diagnostics run in ms. */
+  durationMs: number;
+  /** ISO timestamp when diagnostics were run. */
+  timestamp: string;
+}
+
+// ── Disk ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns free disk space in GB for the volume containing `dir`.
+ * Uses fs.statfs (available in Node >= 18.15 / Electron >= 28) with a
+ * graceful fallback so it never throws.
+ */
+function getFreeDiskGB(dir: string): number | null {
+  try {
+    // fs.statfsSync was added in Node 18.15.0 (Electron 28 ships 18.18.2)
+    const stats = (fs as any).statfsSync(dir) as {
+      bsize: number;
+      bfree: number;
+      bavail: number;
+    };
+    if (stats && typeof stats.bsize === 'number' && typeof stats.bavail === 'number') {
+      return (stats.bavail * stats.bsize) / 1e9;
+    }
+  } catch {
+    // Non-fatal — detection unavailable on this platform/version
+  }
+  return null;
+}
+
+export function buildDiskInfo(freeGB: number | null): DiskInfo {
+  if (freeGB === null) {
+    return { freeGB: null, ok: true, warning: null };
+  }
+  if (freeGB < DISK_BLOCK_GB) {
+    return {
+      freeGB,
+      ok: false,
+      warning: `Only ${freeGB.toFixed(1)} GB free. AI models need at least ${DISK_BLOCK_GB} GB — free up space before continuing.`,
+    };
+  }
+  if (freeGB < DISK_WARN_GB) {
+    return {
+      freeGB,
+      ok: true,
+      warning: `${freeGB.toFixed(1)} GB free. Models use 5–10 GB — consider freeing space before pulling large models.`,
+    };
+  }
+  return { freeGB, ok: true, warning: null };
+}
+
+// ── Service reachability ──────────────────────────────────────────────────────
+
+const REACH_TIMEOUT_MS = 4000;
+
+export async function checkService(url: string): Promise<ServiceStatus> {
+  const start = Date.now();
+  try {
+    const res = await axios.get(url, { timeout: REACH_TIMEOUT_MS, validateStatus: () => true });
+    return {
+      reachable: res.status < 500,
+      url,
+      statusCode: res.status,
+      latencyMs: Date.now() - start,
+    };
+  } catch {
+    return { reachable: false, url, statusCode: null, latencyMs: null };
+  }
+}
+
+// ── Permissions ───────────────────────────────────────────────────────────────
+
+export function checkWritePermissions(userDataPath: string): PermissionsInfo {
+  const testDir = path.join(userDataPath, 'config');
+  const testFile = path.join(testDir, `.diag-write-test-${Date.now()}`);
+  try {
+    if (!fs.existsSync(testDir)) fs.mkdirSync(testDir, { recursive: true });
+    fs.writeFileSync(testFile, 'ok');
+    fs.unlinkSync(testFile);
+    return { canWrite: true, path: userDataPath };
+  } catch {
+    return { canWrite: false, path: userDataPath };
+  }
+}
+
+// ── Hardware ──────────────────────────────────────────────────────────────────
+
+export function vramToProfile(vramGB: number | null): '4gb' | '8gb' | '16gb+' | null {
+  if (vramGB === null) return null;
+  if (vramGB >= 12) return '16gb+';
+  if (vramGB >= 6) return '8gb';
+  return '4gb';
+}
+
+// ── Main entry point ─────────────────────────────────────────────────────────
+
+export interface DiagnosticsInput {
+  ollamaUrl: string;
+  n8nUrl: string;
+  /** Qdrant defaults to localhost:6333 */
+  qdrantUrl?: string;
+}
+
+export async function runDiagnostics(
+  input: DiagnosticsInput,
+  userDataPath: string
+): Promise<DiagnosticsResult> {
+  const start = Date.now();
+  const timestamp = new Date().toISOString();
+
+  const ollamaBase = (input.ollamaUrl || 'http://127.0.0.1:11434').replace(/\/$/, '');
+  const n8nBase = (input.n8nUrl || 'http://localhost:5678').replace(/\/$/, '');
+  const qdrantBase = (input.qdrantUrl || 'http://localhost:6333').replace(/\/$/, '');
+
+  // Run service checks and GPU detection in parallel
+  const [ollamaStatus, n8nStatus, qdrantStatus, gpuResult] = await Promise.all([
+    checkService(`${ollamaBase}/api/tags`),
+    checkService(`${n8nBase}/healthz`),
+    checkService(`${qdrantBase}/healthz`),
+    detectGpuVram().catch(() => ({ vramGB: null as number | null, gpuName: null as string | null, method: 'error' as const })),
+  ]);
+
+  const freeGB = getFreeDiskGB(userDataPath);
+  const disk = buildDiskInfo(freeGB);
+  const permissions = checkWritePermissions(userDataPath);
+  const vramGB = gpuResult.vramGB ?? null;
+
+  return {
+    disk,
+    ollama: ollamaStatus,
+    n8n: n8nStatus,
+    qdrant: qdrantStatus,
+    permissions,
+    hardware: {
+      vramGB,
+      gpuName: gpuResult.gpuName ?? null,
+      profile: vramToProfile(vramGB),
+    },
+    durationMs: Date.now() - start,
+    timestamp,
+  };
+}

--- a/widget/src/main/ipc-handlers.ts
+++ b/widget/src/main/ipc-handlers.ts
@@ -782,6 +782,28 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
     }
   });
 
+
+  // ── Comprehensive first-run diagnostics ───────────────────────────────────
+  // Runs disk-space, service-reachability, write-permissions, and GPU checks
+  // in parallel. All checks are non-destructive and safe to call at any time.
+  ipcMain.handle('homebot:run-diagnostics', async () => {
+    try {
+      const { runDiagnostics } = await import('./diagnostics');
+      const settings = getSettings();
+      const userDataPath = app.getPath('userData');
+      const result = await runDiagnostics(
+        {
+          ollamaUrl: settings.ollamaUrl || 'http://127.0.0.1:11434',
+          n8nUrl: settings.n8nUrl || 'http://localhost:5678',
+        },
+        userDataPath
+      );
+      return { success: true, ...result };
+    } catch (err: any) {
+      return { success: false, error: String(err?.message || err) };
+    }
+  });
+
   // List installed Ollama models via /api/tags
   ipcMain.handle('homebot:list-ollama-models', async () => {
     const ollamaBase = getConfiguredOllamaBaseUrl();

--- a/widget/src/preload/index.ts
+++ b/widget/src/preload/index.ts
@@ -381,6 +381,10 @@ const electronAPI: ElectronAPI = {
     return await ipcRenderer.invoke('homebot:detect-gpu-vram');
   },
 
+  runDiagnostics: async () => {
+    return await ipcRenderer.invoke('homebot:run-diagnostics');
+  },
+
   exportSettings: async () => {
     return await ipcRenderer.invoke('homebot:export-settings');
   },

--- a/widget/src/renderer/components/FirstRunModal.tsx
+++ b/widget/src/renderer/components/FirstRunModal.tsx
@@ -101,6 +101,8 @@ export default function FirstRunModal({
   const [modelsPulled, setModelsPulled] = useState<string[]>([]);
   const [modelPullIndex, setModelPullIndex] = useState(0);
   const [gpuInfo, setGpuInfo] = useState<{ vramGB: number | null; gpuName: string | null } | null>(null);
+  const [diskWarning, setDiskWarning] = useState<string | null>(null);
+  const [diskOk, setDiskOk] = useState<boolean>(true);
   const pullCancelledRef = useRef(false);
 
   // Cloud path state
@@ -182,7 +184,18 @@ export default function FirstRunModal({
   const runLocalSetup = useCallback(async () => {
     setLocalPhase('checking');
     setOllamaError(null);
+    setDiskWarning(null);
+    setDiskOk(true);
     detectHardware();
+
+    // Check disk space before potentially pulling large models
+    try {
+      const diagResult = await (window as any).electron.runDiagnostics?.();
+      if (diagResult?.disk) {
+        setDiskOk(diagResult.disk.ok);
+        setDiskWarning(diagResult.disk.warning ?? null);
+      }
+    } catch { /* non-critical — don't block setup */ }
 
     // 1. Check if Ollama is running
     try {
@@ -413,6 +426,13 @@ export default function FirstRunModal({
                 </div>
               )}
 
+              {/* Disk space warning — shown whenever there is a warning, regardless of phase */}
+              {diskWarning && (
+                <div className={`wizard-status ${diskOk ? 'warning' : 'error'}`}>
+                  💾 {diskWarning}
+                </div>
+              )}
+
               {/* Phase: Checking models */}
               {localPhase === 'checking-models' && (
                 <div className="wizard-status checking">
@@ -552,9 +572,9 @@ export default function FirstRunModal({
                 type="button"
                 onClick={() => setStep('done')}
                 className="first-run-btn first-run-btn-primary"
-                disabled={(setupPath === 'local' && localBusy) || (setupPath === 'cloud' && cloudOk !== true && cloudApiKey.trim().length > 0)}
+                disabled={(setupPath === 'local' && (localBusy || !diskOk)) || (setupPath === 'cloud' && cloudOk !== true && cloudApiKey.trim().length > 0)}
               >
-                {setupPath === 'local' && localPhase === 'ready' ? 'Next' : setupPath === 'local' && localBusy ? 'Setting up...' : setupPath === 'local' ? 'Continue anyway' : 'Next'}
+                {setupPath === 'local' && !diskOk ? 'Free up disk space first' : setupPath === 'local' && localPhase === 'ready' ? 'Next' : setupPath === 'local' && localBusy ? 'Setting up...' : setupPath === 'local' ? 'Continue anyway' : 'Next'}
               </button>
             )}
             {step === 'done' && (


### PR DESCRIPTION
Add homebot:run-diagnostics IPC channel that runs all checks in parallel:
- Disk space (fs.statfsSync, DISK_BLOCK_GB=4, DISK_WARN_GB=10)
- Service reachability: Ollama /api/tags, n8n /healthz, Qdrant /healthz
- Write permissions: temp file in userData/config/
- Hardware: reuses detectGpuVram() → maps to '4gb'|'8gb'|'16gb+'

Changes:
- widget/src/main/diagnostics.ts          new file (203 lines)
- widget/src/main/ipc-handlers.ts         +homebot:run-diagnostics handler
- widget/src/preload/index.ts             +runDiagnostics() bridge
- widget/src/renderer/components/         disk warning + block button
    FirstRunModal.tsx                      when freeGB < 4 GB
- widget/src/main/__tests__/             27 unit tests (6 suites)
    diagnostics.test.ts

Addresses roadmap: 'First-run diagnostics for Ollama, hardware, ports, disk space, and permissions'