### PR TITLE
feat: baseline startup + first-token latency metrics

### DIFF
--- a/widget/src/main/__tests__/perf-logger.test.ts
+++ b/widget/src/main/__tests__/perf-logger.test.ts
@@ -1,0 +1,125 @@
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Point the logger at an isolated temp dir BEFORE importing the module so the
+// electron `app` fallback resolves to TEST_USERDATA.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-logger-test-'));
+process.env.TEST_USERDATA = TMP;
+
+// electron has no `app` in the jest/node env; mock it so getLogDir() falls back.
+jest.mock('electron', () => ({ app: undefined }), { virtual: true });
+
+import {
+  computeLatency,
+  logStartupTime,
+  markRequestStart,
+  markFirstToken,
+  clearRequest,
+  readPerfAggregates,
+  __resetForTests,
+} from '../utils/perf-logger';
+
+const perfLogPath = () => path.join(TMP, 'logs', 'perf.log');
+function readLines(): any[] {
+  if (!fs.existsSync(perfLogPath())) return [];
+  return fs.readFileSync(perfLogPath(), 'utf-8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+beforeEach(() => {
+  __resetForTests();
+  try { fs.rmSync(perfLogPath(), { force: true }); } catch { /* ignore */ }
+});
+
+describe('computeLatency', () => {
+  it('returns rounded non-negative delta', () => {
+    expect(computeLatency(100, 350)).toBe(250);
+    expect(computeLatency(100.4, 350.5)).toBe(250);
+  });
+  it('clamps negative deltas to 0', () => {
+    expect(computeLatency(500, 100)).toBe(0);
+  });
+  it('returns null for invalid inputs', () => {
+    expect(computeLatency(undefined, 100)).toBeNull();
+    expect(computeLatency(NaN, 100)).toBeNull();
+    expect(computeLatency(100, Infinity)).toBeNull();
+  });
+});
+
+describe('logStartupTime', () => {
+  it('writes a startup entry with ms', () => {
+    logStartupTime(1234, { event: 'did-finish-load' });
+    const lines = readLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ type: 'startup', ms: 1234, event: 'did-finish-load' });
+    expect(typeof lines[0].timestamp).toBe('string');
+  });
+  it('ignores invalid values', () => {
+    logStartupTime(-5);
+    logStartupTime(NaN as any);
+    expect(readLines()).toHaveLength(0);
+  });
+});
+
+describe('first-token tracking', () => {
+  it('logs first-token latency once and is idempotent', () => {
+    markRequestStart('s1', 1000);
+    expect(markFirstToken('s1', 1450)).toBe(450);
+    // second call for same stream is a no-op
+    expect(markFirstToken('s1', 1600)).toBeNull();
+    const lines = readLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ type: 'first-token', streamId: 's1', ms: 450 });
+  });
+
+  it('returns null when no request start was recorded', () => {
+    expect(markFirstToken('unknown', 1000)).toBeNull();
+    expect(readLines()).toHaveLength(0);
+  });
+
+  it('clearRequest prevents a later token from logging', () => {
+    markRequestStart('s2', 1000);
+    clearRequest('s2');
+    expect(markFirstToken('s2', 1200)).toBeNull();
+    expect(readLines()).toHaveLength(0);
+  });
+
+  it('ignores empty streamIds', () => {
+    markRequestStart(undefined, 1000);
+    expect(markFirstToken(undefined, 1200)).toBeNull();
+    expect(markFirstToken('', 1200)).toBeNull();
+    expect(readLines()).toHaveLength(0);
+  });
+});
+
+describe('readPerfAggregates', () => {
+  it('summarizes startup and first-token metrics', () => {
+    [100, 200, 300, 400].forEach((ms) => logStartupTime(ms));
+    [10, 20, 30].forEach((ms, i) => { markRequestStart(`r${i}`, 0); markFirstToken(`r${i}`, ms); });
+
+    const agg = readPerfAggregates();
+    expect(agg.startup.count).toBe(4);
+    expect(agg.startup.min_ms).toBe(100);
+    expect(agg.startup.max_ms).toBe(400);
+    expect(agg.startup.avg_ms).toBe(250);
+    expect(agg.startup.last_ms).toBe(400);
+    expect(agg.firstToken.count).toBe(3);
+    expect(agg.firstToken.avg_ms).toBe(20);
+    expect(agg.firstToken.p50_ms).toBeGreaterThan(0);
+  });
+
+  it('returns empty summaries when no log exists', () => {
+    const agg = readPerfAggregates();
+    expect(agg.startup.count).toBe(0);
+    expect(agg.firstToken.count).toBe(0);
+    expect(agg.startup.last_ms).toBeNull();
+  });
+
+  it('skips malformed lines without throwing', () => {
+    fs.mkdirSync(path.join(TMP, 'logs'), { recursive: true });
+    fs.writeFileSync(perfLogPath(), 'not json\n{"type":"startup","ms":500}\n{bad}\n');
+    const agg = readPerfAggregates();
+    expect(agg.startup.count).toBe(1);
+    expect(agg.startup.last_ms).toBe(500);
+  });
+});

--- a/widget/src/main/index.ts
+++ b/widget/src/main/index.ts
@@ -16,6 +16,7 @@ import { initScheduler } from './scheduler';
 import { restoreReminders } from './tools/reminder';
 import { registerWebServicesHandlers, closeAllServiceWindows } from './web-services';
 import { initAutoUpdater, downloadUpdate, installUpdate } from './auto-updater';
+import { logStartupTime } from './utils/perf-logger';
 import { shutdownMcpServers } from './mcp-client';
 import { DEFAULT_OLLAMA_URL } from '../shared/constants';
 import axios from 'axios';
@@ -183,6 +184,18 @@ app.whenReady().then(async () => {
 
   // Create the main window FIRST for fast first-paint, then init tools in background
   mainWindow = createMainWindow();
+
+  // ── Baseline perf metric: total startup time ──────────────────────────
+  // Record ms from process spawn to the renderer being ready (first usable
+  // UI). Persisted to userData/logs/perf.log via perf-logger. Guarded so a
+  // logging failure can never affect launch.
+  try {
+    mainWindow.webContents.once('did-finish-load', () => {
+      try {
+        logStartupTime(Math.round(process.uptime() * 1000), { event: 'did-finish-load' });
+      } catch (e) { safeCatch(e); }
+    });
+  } catch (e) { safeCatch(e); }
 
   // For every <webview> that gets attached to the main window:
   // 1. Re-apply the Chrome UA at the webContents level (strongest override).

--- a/widget/src/main/message-router.ts
+++ b/widget/src/main/message-router.ts
@@ -14,6 +14,7 @@ import { isE2E, isPackagedBuild } from './env';
 import { getSettings, saveSettings } from './config-manager';
 import { logTelemetryEvent } from './utils/logger';
 import { streamFromCustomLLM, validateCustomLLMConfig, PROVIDER_API_URLS } from './custom-llm-client';
+import { markRequestStart, markFirstToken } from './utils/perf-logger';
 import { setTavilyApiKey, setSerperApiKey, setOpenaiApiKey } from './tools/web';
 import { MemoryManager } from './memory-manager';
 import { enrichNbaGames, enrichWeather, enrichGenericQuery } from './tools/enrichment';
@@ -154,6 +155,12 @@ function pushRouter(line: string) {
  */
 function safeSend(sender: Electron.WebContents | undefined, channel: string, data?: any) {
   try {
+    // Baseline perf metric: record first-token latency on the first chunk of a
+    // stream. Idempotent per streamId, so this central hook plus the direct
+    // event.sender.send paths below all resolve to a single logged entry.
+    if (channel === 'homebot:stream-chunk' && data && data.streamId) {
+      try { markFirstToken(data.streamId); } catch (e) { safeCatch(e); }
+    }
     sender?.send(channel, data);
   } catch (err) {
     console.warn(`[HomeBot] IPC send failed (window destroyed?) channel=${channel}`, err);
@@ -3256,6 +3263,8 @@ export function registerMessageRouter(_mainWindow: BrowserWindow, n8nUrl: string
       if (process.env.NODE_ENV !== 'production') console.log('[DIAG] Received homebot:stream-message', { request });
       try { pushRouter(`Received homebot:stream-message conv=${request?.conversation_id} user=${request?.user_id}`); } catch (e) { safeCatch(e); }
       const streamId = request?.streamId || `stream-${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+      // Baseline perf metric: stamp request arrival for first-token latency.
+      try { markRequestStart(streamId, streamStartMs); } catch (e) { safeCatch(e); }
 
       if (!request || typeof request !== 'object' || !request.user_id || !request.message || !request.conversation_id) {
         event.sender.send('homebot:stream-error', { error: true, message: 'Invalid request format.', streamId });
@@ -4399,6 +4408,7 @@ export function registerMessageRouter(_mainWindow: BrowserWindow, n8nUrl: string
                 const ttfb = Date.now() - streamStartMs;
                 console.log(`[PERF] TTFB streamId=${streamId} ${ttfb}ms`);
                 try { event.sender.send('homebot:stream-ttfb', { streamId, ttfbMs: ttfb }); } catch (e) { safeCatch(e); }
+                try { markFirstToken(streamId); } catch (e) { safeCatch(e); }
               }
               assistantResponse += chunk;
               try { pushRouter(`OLLAMA emitted chunk streamId=${streamId} len=${String(chunk?.length ?? 0)}`); } catch (e) { safeCatch(e); }
@@ -4455,6 +4465,7 @@ export function registerMessageRouter(_mainWindow: BrowserWindow, n8nUrl: string
               proxyAssistantResponse += text;
               // forward raw chunk to renderer
               try { pushRouter(`PROXY emitted chunk streamId=${streamId} len=${String(chunk).length}`); } catch (e) { safeCatch(e); }
+              try { markFirstToken(streamId); } catch (e) { safeCatch(e); }
               event.sender.send('homebot:stream-chunk', { chunk: text, streamId });
                           if (E2E) {
                             console.log('[E2E-TRACE] stream-chunk (proxy)', { streamId, chunkLen: String(chunk).length, snippet: String(chunk).substring(0, 120) });
@@ -5035,6 +5046,7 @@ export function registerMessageRouter(_mainWindow: BrowserWindow, n8nUrl: string
                   if (!activeStreams.has(streamId)) return;
                   llmAssistantResponse += chunk;
                   try { pushRouter(`LLM emitted chunk streamId=${streamId} len=${String(chunk).length}`); } catch (e) { safeCatch(e); }
+                  try { markFirstToken(streamId); } catch (e) { safeCatch(e); }
                   try { event.sender.send('homebot:stream-chunk', { chunk, streamId }); } catch (e) { safeCatch(e); }
                   if (process.env.NODE_ENV !== 'production') logDebug('[DIAG] direct-ollama chunk', { streamId, len: String(chunk).length, snippet: String(chunk).substring(0,120) });
                 },

--- a/widget/src/main/utils/perf-logger.ts
+++ b/widget/src/main/utils/perf-logger.ts
@@ -1,0 +1,193 @@
+import { app } from 'electron';
+import os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * perf-logger — baseline performance metrics for HomeBot / SADIE.
+ *
+ * Persists two metrics as JSONL to `<userData>/logs/perf.log`:
+ *   1. `startup`     — ms from process spawn to the main window being ready.
+ *   2. `first-token` — ms from a chat request arriving to its first streamed
+ *                      chunk (time-to-first-token, TTFT).
+ *
+ * Design notes:
+ *   - Never throws. Perf logging must never break the app, so every public
+ *     function is fully guarded. Failures degrade to a console warning.
+ *   - Pure timing math (`computeLatency`) and the request-tracking map are
+ *     unit-testable without Electron; tests point `TEST_USERDATA` at a temp dir.
+ *   - `markFirstToken` is idempotent per streamId: the request start entry is
+ *     consumed on the first call, so duplicate calls from overlapping send
+ *     sites are harmless no-ops.
+ */
+
+const STARTUP = 'startup';
+const FIRST_TOKEN = 'first-token';
+
+// Bound the in-flight request map so a stream that never emits a token (and is
+// never explicitly cleared) cannot leak memory over a long session.
+const MAX_TRACKED_REQUESTS = 500;
+
+// streamId -> request-received epoch ms
+const requestStarts = new Map<string, number>();
+
+function getLogDir(): string {
+  try {
+    const userPath = (app && typeof app.getPath === 'function')
+      ? app.getPath('userData')
+      : (process.env.TEST_USERDATA || os.tmpdir());
+    return path.join(userPath, 'logs');
+  } catch {
+    return path.join(process.env.TEST_USERDATA || os.tmpdir(), 'logs');
+  }
+}
+
+function getPerfLogPath(): string {
+  return path.join(getLogDir(), 'perf.log');
+}
+
+function ensureLogDir(): void {
+  try {
+    const dir = getLogDir();
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    /* ignore — append will simply no-op */
+  }
+}
+
+/** Pure, testable latency helper. Returns a non-negative integer ms, or null. */
+export function computeLatency(startMs: number | undefined, endMs: number): number | null {
+  if (typeof startMs !== 'number' || !Number.isFinite(startMs)) return null;
+  if (typeof endMs !== 'number' || !Number.isFinite(endMs)) return null;
+  return Math.max(0, Math.round(endMs - startMs));
+}
+
+function appendEntry(entry: Record<string, any>): void {
+  try {
+    ensureLogDir();
+    const line = JSON.stringify({ timestamp: new Date().toISOString(), ...entry }) + '\n';
+    fs.appendFileSync(getPerfLogPath(), line);
+  } catch (err) {
+    console.warn('[PERF] Failed to write perf.log entry:', (err as any)?.message || err);
+  }
+}
+
+/**
+ * Record total startup time (ms from process spawn to UI ready).
+ * Call once per launch, typically on the main window's `did-finish-load`.
+ */
+export function logStartupTime(ms: number, details: Record<string, any> = {}): void {
+  if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return;
+  appendEntry({ type: STARTUP, ms: Math.round(ms), ...details });
+}
+
+/**
+ * Mark the moment a chat request arrives. `atMs` lets the caller pass an
+ * already-captured timestamp so the recorded latency lines up with other
+ * measurements taken at the handler entry.
+ */
+export function markRequestStart(streamId: string | undefined, atMs: number = Date.now()): void {
+  if (!streamId) return;
+  try {
+    // Evict the oldest entry if we are at capacity (insertion-ordered Map).
+    if (requestStarts.size >= MAX_TRACKED_REQUESTS) {
+      const oldest = requestStarts.keys().next().value;
+      if (oldest !== undefined) requestStarts.delete(oldest);
+    }
+    requestStarts.set(streamId, atMs);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Record first-token latency for a stream. Idempotent: consumes the stored
+ * start time so only the first chunk of a given stream is logged. Returns the
+ * latency in ms when logged, or null if there was nothing to log.
+ */
+export function markFirstToken(streamId: string | undefined, atMs: number = Date.now()): number | null {
+  if (!streamId) return null;
+  let start: number | undefined;
+  try {
+    start = requestStarts.get(streamId);
+    if (start === undefined) return null;
+    requestStarts.delete(streamId); // consume -> idempotent
+  } catch {
+    return null;
+  }
+  const ms = computeLatency(start, atMs);
+  if (ms === null) return null;
+  appendEntry({ type: FIRST_TOKEN, streamId, ms });
+  return ms;
+}
+
+/** Drop a tracked request without logging (e.g. stream errored before any token). */
+export function clearRequest(streamId: string | undefined): void {
+  if (!streamId) return;
+  try { requestStarts.delete(streamId); } catch { /* ignore */ }
+}
+
+/** Test-only: reset in-memory tracking between cases. */
+export function __resetForTests(): void {
+  requestStarts.clear();
+}
+
+export interface PerfStat {
+  count: number;
+  avg_ms: number;
+  p50_ms: number;
+  p95_ms: number;
+  min_ms: number;
+  max_ms: number;
+  last_ms: number | null;
+}
+
+function summarize(values: number[]): PerfStat {
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const pct = (q: number) => (n ? sorted[Math.min(n - 1, Math.floor(q * n))]! : 0);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  return {
+    count: n,
+    avg_ms: n ? Math.round(sum / n) : 0,
+    p50_ms: pct(0.5),
+    p95_ms: pct(0.95),
+    min_ms: n ? sorted[0]! : 0,
+    max_ms: n ? sorted[n - 1]! : 0,
+    last_ms: n ? values[values.length - 1]! : null,
+  };
+}
+
+/**
+ * Read and aggregate perf.log. Returns startup + first-token summaries
+ * (count, avg, p50, p95, min, max, last) for a lightweight perf dashboard.
+ */
+export function readPerfAggregates(): { startup: PerfStat; firstToken: PerfStat } {
+  const startupVals: number[] = [];
+  const firstTokenVals: number[] = [];
+  try {
+    const file = getPerfLogPath();
+    if (fs.existsSync(file)) {
+      const lines = fs.readFileSync(file, 'utf-8').trim().split('\n').filter(Boolean);
+      for (const line of lines) {
+        let evt: any;
+        try { evt = JSON.parse(line); } catch { continue; }
+        if (typeof evt?.ms !== 'number') continue;
+        if (evt.type === STARTUP) startupVals.push(evt.ms);
+        else if (evt.type === FIRST_TOKEN) firstTokenVals.push(evt.ms);
+      }
+    }
+  } catch {
+    /* fall through to empty summaries */
+  }
+  return { startup: summarize(startupVals), firstToken: summarize(firstTokenVals) };
+}
+
+export default {
+  computeLatency,
+  logStartupTime,
+  markRequestStart,
+  markFirstToken,
+  clearRequest,
+  readPerfAggregates,
+};


### PR DESCRIPTION
Persist two baseline performance metrics as JSONL to `userData/logs/perf.log`:

- **startup** — ms from process spawn to renderer ready (logged on main window `did-finish-load` in `index.ts`)
- **first-token (TTFT)** — ms from chat-request arrival to first streamed chunk (`markRequestStart` at the stream-message handler entry; `markFirstToken` at the ollama/proxy/direct-ollama chunk paths + a central idempotent hook in `safeSend`)

The logger never throws, keeps a bounded in-flight map, and exposes `readPerfAggregates()` (count/avg/p50/p95/min/max/last) for a future perf dashboard.

**Files**
- `widget/src/main/utils/perf-logger.ts` — new module
- `widget/src/main/index.ts` — startup timing on `did-finish-load`
- `widget/src/main/message-router.ts` — TTFT instrumentation

**Tests:** `perf-logger.test.ts` — unit coverage of logging, aggregates, and bounded in-flight map.

Base: `main`. First in the perf stack — `perf-metrics-diagnostics-ui` and `perf-trend-sparkline` build on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz)_