### PR TITLE
feat: surface baseline perf metrics in Settings (Diagnostics & Performance)

### DIFF
--- a/widget/src/main/__tests__/perf-history.test.ts
+++ b/widget/src/main/__tests__/perf-history.test.ts
@@ -1,0 +1,80 @@
+/**
+ * perf-history.test.ts — tests for readPerfHistory() in utils/perf-logger.ts
+ * Isolated temp userData dir; electron app mocked away.
+ */
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-history-test-'));
+process.env.TEST_USERDATA = TMP;
+
+jest.mock('electron', () => ({ app: undefined }), { virtual: true });
+
+import {
+  logStartupTime,
+  markRequestStart,
+  markFirstToken,
+  readPerfHistory,
+  __resetForTests,
+} from '../utils/perf-logger';
+
+const perfLogPath = () => path.join(TMP, 'logs', 'perf.log');
+
+beforeEach(() => {
+  __resetForTests();
+  try { fs.rmSync(perfLogPath(), { force: true }); } catch { /* ignore */ }
+});
+
+describe('readPerfHistory', () => {
+  test('returns empty arrays when no log exists', () => {
+    const h = readPerfHistory();
+    expect(h).toEqual({ startup: [], firstToken: [] });
+  });
+
+  test('collects startup and first-token samples in chronological order', () => {
+    logStartupTime(1000);
+    logStartupTime(1100);
+    logStartupTime(1200);
+    // first-token samples via mark start→token
+    markRequestStart('a', 0);
+    markFirstToken('a', 300);
+    markRequestStart('b', 0);
+    markFirstToken('b', 450);
+
+    const h = readPerfHistory();
+    expect(h.startup).toEqual([1000, 1100, 1200]);
+    expect(h.firstToken).toEqual([300, 450]);
+  });
+
+  test('limit keeps only the most recent N of each, newest last', () => {
+    for (let i = 1; i <= 30; i++) logStartupTime(i * 10);
+    const h = readPerfHistory(5);
+    expect(h.startup).toHaveLength(5);
+    expect(h.startup).toEqual([260, 270, 280, 290, 300]);
+  });
+
+  test('invalid limit falls back to default of 20', () => {
+    for (let i = 1; i <= 25; i++) logStartupTime(i);
+    const h = readPerfHistory(0);
+    expect(h.startup).toHaveLength(20);
+    expect(h.startup[h.startup.length - 1]).toBe(25);
+  });
+
+  test('ignores malformed log lines without throwing', () => {
+    const dir = path.join(TMP, 'logs');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      perfLogPath(),
+      [
+        JSON.stringify({ type: 'startup', ms: 800 }),
+        'not json at all',
+        JSON.stringify({ type: 'first-token', ms: 'oops' }),
+        JSON.stringify({ type: 'first-token', ms: 250 }),
+      ].join('\n') + '\n',
+    );
+    const h = readPerfHistory();
+    expect(h.startup).toEqual([800]);
+    expect(h.firstToken).toEqual([250]);
+  });
+});

--- a/widget/src/main/ipc-handlers.ts
+++ b/widget/src/main/ipc-handlers.ts
@@ -1,5 +1,6 @@
 import { ipcMain, BrowserWindow, app, shell } from 'electron';
 import { getMainWindow, toggleWidgetMode, getWidgetMode } from './window-manager';
+import { readPerfAggregates } from './utils/perf-logger';
 
 /** Catch handler for fire-and-forget ops — logs instead of silently swallowing */
 function safeCatch(e: unknown) { console.error('[HomeBot-CATCH]', e); }
@@ -194,6 +195,17 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
       saveSettings(settings); // This function is already imported from config-manager
       try { setUncensoredMode(enabled); } catch (e) { console.error('[IPC] Failed to set uncensored mode runtime flag:', (e as any)?.message || e); }
       return { success: true, enabled: settings.uncensoredMode };
+    });
+
+    // Baseline perf metrics (startup + first-token/TTFT aggregates) for the Diagnostics & Performance UI
+    ipcMain.handle('homebot:get-perf-aggregates', async () => {
+      try {
+        return readPerfAggregates();
+      } catch (e) {
+        console.error('[IPC] get-perf-aggregates failed:', (e as any)?.message || e);
+        const empty = { count: 0, avg_ms: 0, p50_ms: 0, p95_ms: 0, min_ms: 0, max_ms: 0, last_ms: null };
+        return { startup: empty, firstToken: { ...empty } };
+      }
     });
 
     ipcMain.on('window-minimize', () => {

--- a/widget/src/main/ipc-handlers.ts
+++ b/widget/src/main/ipc-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, BrowserWindow, app, shell } from 'electron';
 import { getMainWindow, toggleWidgetMode, getWidgetMode } from './window-manager';
-import { readPerfAggregates } from './utils/perf-logger';
+import { readPerfAggregates, readPerfHistory } from './utils/perf-logger';
 
 /** Catch handler for fire-and-forget ops — logs instead of silently swallowing */
 function safeCatch(e: unknown) { console.error('[HomeBot-CATCH]', e); }
@@ -205,6 +205,16 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
         console.error('[IPC] get-perf-aggregates failed:', (e as any)?.message || e);
         const empty = { count: 0, avg_ms: 0, p50_ms: 0, p95_ms: 0, min_ms: 0, max_ms: 0, last_ms: null };
         return { startup: empty, firstToken: { ...empty } };
+      }
+    });
+
+    // Raw recent samples (chronological) for the Diagnostics trend sparklines
+    ipcMain.handle('homebot:get-perf-history', async (_evt, limit?: number) => {
+      try {
+        return readPerfHistory(typeof limit === 'number' ? limit : 20);
+      } catch (e) {
+        console.error('[IPC] get-perf-history failed:', (e as any)?.message || e);
+        return { startup: [], firstToken: [] };
       }
     });
 

--- a/widget/src/main/utils/perf-logger.ts
+++ b/widget/src/main/utils/perf-logger.ts
@@ -158,6 +158,44 @@ function summarize(values: number[]): PerfStat {
   };
 }
 
+export interface PerfHistory {
+  startup: number[];
+  firstToken: number[];
+}
+
+/**
+ * Read the most recent raw samples from perf.log for trend sparklines.
+ *
+ * Returns up to `limit` startup and first-token `ms` values each, in
+ * chronological order (oldest -> newest), so the renderer can draw a left->right
+ * trend line. Never throws; on any error it returns empty arrays.
+ */
+export function readPerfHistory(limit = 20): PerfHistory {
+  const startup: number[] = [];
+  const firstToken: number[] = [];
+  const cap = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20;
+  try {
+    const file = getPerfLogPath();
+    if (fs.existsSync(file)) {
+      const lines = fs.readFileSync(file, 'utf-8').trim().split('\n').filter(Boolean);
+      for (const line of lines) {
+        let evt: any;
+        try { evt = JSON.parse(line); } catch { continue; }
+        if (typeof evt?.ms !== 'number' || !Number.isFinite(evt.ms)) continue;
+        if (evt.type === STARTUP) startup.push(evt.ms);
+        else if (evt.type === FIRST_TOKEN) firstToken.push(evt.ms);
+      }
+    }
+  } catch {
+    return { startup: [], firstToken: [] };
+  }
+  // Keep only the most recent `cap` of each, preserving chronological order.
+  return {
+    startup: startup.slice(-cap),
+    firstToken: firstToken.slice(-cap),
+  };
+}
+
 /**
  * Read and aggregate perf.log. Returns startup + first-token summaries
  * (count, avg, p50, p95, min, max, last) for a lightweight perf dashboard.
@@ -190,4 +228,5 @@ export default {
   markFirstToken,
   clearRequest,
   readPerfAggregates,
+  readPerfHistory,
 };

--- a/widget/src/preload/index.ts
+++ b/widget/src/preload/index.ts
@@ -316,6 +316,10 @@ const electronAPI: ElectronAPI = {
     return await ipcRenderer.invoke('homebot:get-perf-aggregates');
   },
 
+  getPerfHistory: async (limit?: number): Promise<{ startup: number[]; firstToken: number[] }> => {
+    return await ipcRenderer.invoke('homebot:get-perf-history', typeof limit === 'number' ? limit : 20);
+  },
+
   getMode: async (): Promise<{ demo: boolean }> => {
     return await ipcRenderer.invoke(ALLOWED_CHANNELS.GET_MODE);
   },

--- a/widget/src/preload/index.ts
+++ b/widget/src/preload/index.ts
@@ -30,6 +30,7 @@ import {
   HomeBotResponse,
   ConnectionStatus,
   ElectronAPI,
+  PerfStatSummary,
   Settings,
   StoredConversation,
   ConversationStore,
@@ -309,6 +310,10 @@ const electronAPI: ElectronAPI = {
 
   readDebugLogs: async (): Promise<{ success: boolean; rendererLogs?: string[]; mainLogs?: string[]; conversationStore?: any; error?: string }> => {
     return await ipcRenderer.invoke('homebot:read-debug-logs');
+  },
+
+  getPerfAggregates: async (): Promise<{ startup: PerfStatSummary; firstToken: PerfStatSummary }> => {
+    return await ipcRenderer.invoke('homebot:get-perf-aggregates');
   },
 
   getMode: async (): Promise<{ demo: boolean }> => {

--- a/widget/src/renderer/__tests__/perf-diagnostics.test.tsx
+++ b/widget/src/renderer/__tests__/perf-diagnostics.test.tsx
@@ -85,7 +85,12 @@ describe('SettingsPanel — Diagnostics & Performance', () => {
 
     await waitFor(() => expect(getPerf).toHaveBeenCalledTimes(1));
 
-    const refreshBtn = Array.from(container.querySelectorAll('button'))
+    // Scope to the Performance metrics group — other sections (e.g. Telemetry
+    // Consent Log) also render a "Refresh" button, and it appears earlier in the DOM.
+    const perfGroup = Array.from(container.querySelectorAll('.setting-group'))
+      .find(g => g.textContent?.includes('Performance metrics')) as HTMLElement;
+    expect(perfGroup).toBeTruthy();
+    const refreshBtn = Array.from(perfGroup.querySelectorAll('button'))
       .find(b => b.textContent === 'Refresh') as HTMLButtonElement;
     expect(refreshBtn).toBeTruthy();
     fireEvent.click(refreshBtn);

--- a/widget/src/renderer/__tests__/perf-diagnostics.test.tsx
+++ b/widget/src/renderer/__tests__/perf-diagnostics.test.tsx
@@ -1,0 +1,95 @@
+/** @jest-environment jsdom */
+
+import { render, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../components/TelemetryConsentModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/TelemetryDashboard', () => ({ __esModule: true, default: () => null }));
+
+import SettingsPanel from '../components/SettingsPanel';
+
+const baseSettings = {
+  alwaysOnTop: true,
+  n8nUrl: 'http://localhost:5678',
+  widgetHotkey: 'Ctrl+Shift+Space',
+};
+
+const noop = () => {};
+
+const emptyStat = { count: 0, avg_ms: 0, p50_ms: 0, p95_ms: 0, min_ms: 0, max_ms: 0, last_ms: null };
+const sampleStartup = { count: 3, avg_ms: 1200, p50_ms: 1200, p95_ms: 1500, min_ms: 900, max_ms: 1500, last_ms: 1500 };
+const sampleFirstToken = { count: 2, avg_ms: 375, p50_ms: 450, p95_ms: 450, min_ms: 300, max_ms: 450, last_ms: 450 };
+
+function baseElectron(getPerfAggregates: jest.Mock) {
+  return {
+    getUncensoredMode: jest.fn().mockResolvedValue({ enabled: false }),
+    mcpListServers: jest.fn().mockResolvedValue([]),
+    mcpGetStatus: jest.fn().mockResolvedValue([]),
+    schedulerList: jest.fn().mockResolvedValue([]),
+    listOllamaModels: jest.fn().mockResolvedValue({ success: true, models: [] }),
+    getPerfAggregates,
+  };
+}
+
+function expandSection(container: HTMLElement, label: string) {
+  const toggles = Array.from(container.querySelectorAll('.sp-section-toggle'));
+  const btn = toggles.find(t => t.textContent?.includes(label)) as HTMLElement | undefined;
+  if (btn && btn.textContent?.includes('▸')) fireEvent.click(btn);
+}
+
+describe('SettingsPanel — Diagnostics & Performance', () => {
+  afterEach(() => {
+    delete (window as any).electron;
+    jest.clearAllMocks();
+  });
+
+  test('renders p50/p95 badges when perf samples exist', async () => {
+    const getPerf = jest.fn().mockResolvedValue({ startup: sampleStartup, firstToken: sampleFirstToken });
+    (window as any).electron = baseElectron(getPerf);
+
+    const { container } = render(
+      <SettingsPanel settings={baseSettings as any} onSave={noop} onClose={noop} />
+    );
+    expandSection(container, 'Diagnostics');
+
+    await waitFor(() => expect(getPerf).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(container.textContent).toContain('p50 1200 ms');
+      expect(container.textContent).toContain('p95 1500 ms');
+      expect(container.textContent).toContain('p50 450 ms');
+    });
+  });
+
+  test('shows empty-state when there are no samples', async () => {
+    const getPerf = jest.fn().mockResolvedValue({ startup: { ...emptyStat }, firstToken: { ...emptyStat } });
+    (window as any).electron = baseElectron(getPerf);
+
+    const { container } = render(
+      <SettingsPanel settings={baseSettings as any} onSave={noop} onClose={noop} />
+    );
+    expandSection(container, 'Diagnostics');
+
+    await waitFor(() => expect(getPerf).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(container.textContent).toContain('No performance samples yet');
+    });
+  });
+
+  test('Refresh re-queries the perf aggregates IPC', async () => {
+    const getPerf = jest.fn().mockResolvedValue({ startup: sampleStartup, firstToken: sampleFirstToken });
+    (window as any).electron = baseElectron(getPerf);
+
+    const { container } = render(
+      <SettingsPanel settings={baseSettings as any} onSave={noop} onClose={noop} />
+    );
+    expandSection(container, 'Diagnostics');
+
+    await waitFor(() => expect(getPerf).toHaveBeenCalledTimes(1));
+
+    const refreshBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent === 'Refresh') as HTMLButtonElement;
+    expect(refreshBtn).toBeTruthy();
+    fireEvent.click(refreshBtn);
+
+    await waitFor(() => expect(getPerf).toHaveBeenCalledTimes(2));
+  });
+});

--- a/widget/src/renderer/__tests__/perf-sparkline.test.tsx
+++ b/widget/src/renderer/__tests__/perf-sparkline.test.tsx
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+
+import { render, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../components/TelemetryConsentModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/TelemetryDashboard', () => ({ __esModule: true, default: () => null }));
+
+import SettingsPanel from '../components/SettingsPanel';
+
+const baseSettings = {
+  alwaysOnTop: true,
+  n8nUrl: 'http://localhost:5678',
+  widgetHotkey: 'Ctrl+Shift+Space',
+};
+const noop = () => {};
+
+const sampleStartup = { count: 3, avg_ms: 1200, p50_ms: 1200, p95_ms: 1500, min_ms: 900, max_ms: 1500, last_ms: 1500 };
+const sampleFirstToken = { count: 2, avg_ms: 375, p50_ms: 450, p95_ms: 450, min_ms: 300, max_ms: 450, last_ms: 450 };
+const emptyStat = { count: 0, avg_ms: 0, p50_ms: 0, p95_ms: 0, min_ms: 0, max_ms: 0, last_ms: null };
+
+function electronWith(getPerfAggregates: jest.Mock, getPerfHistory: jest.Mock) {
+  return {
+    getUncensoredMode: jest.fn().mockResolvedValue({ enabled: false }),
+    mcpListServers: jest.fn().mockResolvedValue([]),
+    mcpGetStatus: jest.fn().mockResolvedValue([]),
+    schedulerList: jest.fn().mockResolvedValue([]),
+    listOllamaModels: jest.fn().mockResolvedValue({ success: true, models: [] }),
+    getPerfAggregates,
+    getPerfHistory,
+  };
+}
+
+function expandSection(container: HTMLElement, label: string) {
+  const toggles = Array.from(container.querySelectorAll('.sp-section-toggle'));
+  const btn = toggles.find(t => t.textContent?.includes(label)) as HTMLElement | undefined;
+  if (btn && btn.textContent?.includes('▸')) fireEvent.click(btn);
+}
+
+describe('SettingsPanel — perf trend sparkline', () => {
+  afterEach(() => {
+    delete (window as any).electron;
+    jest.clearAllMocks();
+  });
+
+  test('renders an SVG sparkline when history has 2+ samples', async () => {
+    const getPerf = jest.fn().mockResolvedValue({ startup: sampleStartup, firstToken: sampleFirstToken });
+    const getHist = jest.fn().mockResolvedValue({ startup: [900, 1200, 1500], firstToken: [300, 450] });
+    (window as any).electron = electronWith(getPerf, getHist);
+
+    const { container } = render(<SettingsPanel settings={baseSettings as any} onSave={noop} onClose={noop} />);
+    expandSection(container, 'Diagnostics');
+
+    await waitFor(() => expect(getHist).toHaveBeenCalled());
+    await waitFor(() => {
+      const svgs = container.querySelectorAll('svg.perf-sparkline');
+      expect(svgs.length).toBeGreaterThanOrEqual(1);
+      expect(container.textContent).toContain('latest 1500 ms');
+    });
+  });
+
+  test('does not render a sparkline when history has fewer than 2 samples', async () => {
+    const getPerf = jest.fn().mockResolvedValue({ startup: { ...emptyStat, count: 1, last_ms: 1000 }, firstToken: { ...emptyStat } });
+    const getHist = jest.fn().mockResolvedValue({ startup: [1000], firstToken: [] });
+    (window as any).electron = electronWith(getPerf, getHist);
+
+    const { container } = render(<SettingsPanel settings={baseSettings as any} onSave={noop} onClose={noop} />);
+    expandSection(container, 'Diagnostics');
+
+    await waitFor(() => expect(getHist).toHaveBeenCalled());
+    await waitFor(() => expect(getPerf).toHaveBeenCalled());
+    expect(container.querySelectorAll('svg.perf-sparkline').length).toBe(0);
+  });
+
+  test('Refresh re-queries the history IPC', async () => {
+    const getPerf = jest.fn().mockResolvedValue({ startup: sampleStartup, firstToken: sampleFirstToken });
+    const getHist = jest.fn().mockResolvedValue({ startup: [900, 1200, 1500], firstToken: [300, 450] });
+    (window as any).electron = electronWith(getPerf, getHist);
+
+    const { container } = render(<SettingsPanel settings={baseSettings as any} onSave={noop} onClose={noop} />);
+    expandSection(container, 'Diagnostics');
+
+    await waitFor(() => expect(getHist).toHaveBeenCalledTimes(1));
+    // Scope to the Performance metrics group — other sections (e.g. Telemetry
+    // Consent Log) also render a "Refresh" button, and it appears earlier in the DOM.
+    const perfGroup = Array.from(container.querySelectorAll('.setting-group'))
+      .find(g => g.textContent?.includes('Performance metrics')) as HTMLElement;
+    const refreshBtn = Array.from(perfGroup.querySelectorAll('button')).find(b => b.textContent === 'Refresh') as HTMLButtonElement;
+    fireEvent.click(refreshBtn);
+    await waitFor(() => expect(getHist).toHaveBeenCalledTimes(2));
+  });
+});

--- a/widget/src/renderer/components/SettingsPanel.tsx
+++ b/widget/src/renderer/components/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import TelemetryConsentModal from './TelemetryConsentModal';
 import TelemetryDashboard from './TelemetryDashboard';
-import type { Settings as SharedSettings, CustomLLMConfig, CustomModelInfo, ScheduledJob } from '../../shared/types';
+import type { Settings as SharedSettings, CustomLLMConfig, CustomModelInfo, ScheduledJob, PerfStatSummary } from '../../shared/types';
 
 interface Settings {
   alwaysOnTop: boolean;
@@ -185,8 +185,25 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
     appearance: true,
     permissions: true,
     advanced: true,
+    diagnostics: false,
   });
   const toggleSection = (id: string) => setOpenSections(s => ({ ...s, [id]: !s[id] }));
+
+  // Diagnostics & Performance: baseline startup + first-token (TTFT) aggregates
+  const [perfStats, setPerfStats] = useState<{ startup: PerfStatSummary; firstToken: PerfStatSummary } | null>(null);
+  const [perfLoading, setPerfLoading] = useState(false);
+  const loadPerfStats = async () => {
+    setPerfLoading(true);
+    try {
+      const r = await window.electron?.getPerfAggregates?.();
+      if (r) setPerfStats(r);
+    } catch { /* ignore — empty-state will render */ }
+    finally { setPerfLoading(false); }
+  };
+  useEffect(() => {
+    if (openSections.diagnostics && !perfStats && !perfLoading) { void loadPerfStats(); }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openSections.diagnostics]);
 
   // Fetch installed Ollama models on mount
   useEffect(() => {
@@ -1995,6 +2012,50 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
           </label>
         </div>
       </div>
+
+
+        {/* Diagnostics & Performance */}
+        <button type="button" className={`sp-section-toggle${openSections.diagnostics ? ' open' : ''}`} onClick={() => toggleSection('diagnostics')}>
+          <span className="sp-section-arrow">{openSections.diagnostics ? '\u25be' : '\u25b8'}</span> Diagnostics &amp; Performance
+        </button>
+        {openSections.diagnostics && <>
+          <div className="setting-group">
+            <label className="setting-label">⚡ Performance metrics</label>
+            <small className="setting-hint">Baseline timings collected locally on this device. Startup = app launch → ready; First-token (TTFT) = chat request → first streamed token.</small>
+            {(() => {
+              const hasData = !!perfStats && (perfStats.startup.count > 0 || perfStats.firstToken.count > 0);
+              if (perfLoading && !perfStats) {
+                return <div className="perf-empty">Loading metrics…</div>;
+              }
+              if (!hasData) {
+                return <div className="perf-empty">No performance samples yet. Use HomeBot for a bit — startup and chat timings will appear here.</div>;
+              }
+              const Row = ({ title, stat }: { title: string; stat: PerfStatSummary }) => (
+                <div className="perf-row">
+                  <div className="perf-row-title">{title}</div>
+                  {stat.count > 0 ? (
+                    <div className="perf-badges">
+                      <span className="perf-badge perf-badge-p50" title="50th percentile (median)">p50 {stat.p50_ms} ms</span>
+                      <span className="perf-badge perf-badge-p95" title="95th percentile">p95 {stat.p95_ms} ms</span>
+                      <span className="perf-badge-meta">avg {stat.avg_ms} · min {stat.min_ms} · max {stat.max_ms} · n={stat.count}</span>
+                    </div>
+                  ) : (
+                    <div className="perf-badges"><span className="perf-badge-meta">no samples</span></div>
+                  )}
+                </div>
+              );
+              return (
+                <div className="perf-metrics">
+                  <Row title="Startup" stat={perfStats!.startup} />
+                  <Row title="First token (TTFT)" stat={perfStats!.firstToken} />
+                </div>
+              );
+            })()}
+            <button type="button" className="button button-cancel" style={{ marginTop: 8 }} onClick={() => { void loadPerfStats(); }} disabled={perfLoading}>
+              {perfLoading ? 'Refreshing\u2026' : 'Refresh'}
+            </button>
+          </div>
+        </>}
 
       </div>{/* end settings-body */}
 

--- a/widget/src/renderer/components/SettingsPanel.tsx
+++ b/widget/src/renderer/components/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import TelemetryConsentModal from './TelemetryConsentModal';
 import TelemetryDashboard from './TelemetryDashboard';
 import type { Settings as SharedSettings, CustomLLMConfig, CustomModelInfo, ScheduledJob, PerfStatSummary } from '../../shared/types';
+import { buildSparkline } from '../../shared/sparkline';
 
 interface Settings {
   alwaysOnTop: boolean;
@@ -191,12 +192,17 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
 
   // Diagnostics & Performance: baseline startup + first-token (TTFT) aggregates
   const [perfStats, setPerfStats] = useState<{ startup: PerfStatSummary; firstToken: PerfStatSummary } | null>(null);
+  const [perfHistory, setPerfHistory] = useState<{ startup: number[]; firstToken: number[] } | null>(null);
   const [perfLoading, setPerfLoading] = useState(false);
   const loadPerfStats = async () => {
     setPerfLoading(true);
     try {
-      const r = await window.electron?.getPerfAggregates?.();
+      const [r, h] = await Promise.all([
+        window.electron?.getPerfAggregates?.(),
+        window.electron?.getPerfHistory?.(20),
+      ]);
       if (r) setPerfStats(r);
+      if (h) setPerfHistory(h);
     } catch { /* ignore — empty-state will render */ }
     finally { setPerfLoading(false); }
   };
@@ -2030,7 +2036,28 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
               if (!hasData) {
                 return <div className="perf-empty">No performance samples yet. Use HomeBot for a bit — startup and chat timings will appear here.</div>;
               }
-              const Row = ({ title, stat }: { title: string; stat: PerfStatSummary }) => (
+              const Sparkline = ({ series }: { series: number[] }) => {
+                const geo = buildSparkline(series, { width: 120, height: 26, padding: 3 });
+                if (!geo.hasData) return null;
+                return (
+                  <svg
+                    className="perf-sparkline"
+                    width={geo.width}
+                    height={geo.height}
+                    viewBox={`0 0 ${geo.width} ${geo.height}`}
+                    role="img"
+                    aria-label={`Trend of last ${series.length} samples — min ${geo.min} ms, max ${geo.max} ms, latest ${geo.last} ms`}
+                    preserveAspectRatio="none"
+                  >
+                    <path d={geo.areaPath} fill="currentColor" fillOpacity={0.12} stroke="none" />
+                    <path d={geo.linePath} fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+                    {geo.points.length > 0 && (
+                      <circle cx={geo.points[geo.points.length - 1].x} cy={geo.points[geo.points.length - 1].y} r={2} fill="currentColor" />
+                    )}
+                  </svg>
+                );
+              };
+              const Row = ({ title, stat, series }: { title: string; stat: PerfStatSummary; series: number[] }) => (
                 <div className="perf-row">
                   <div className="perf-row-title">{title}</div>
                   {stat.count > 0 ? (
@@ -2042,12 +2069,20 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                   ) : (
                     <div className="perf-badges"><span className="perf-badge-meta">no samples</span></div>
                   )}
+                  {series.length > 1 && (
+                    <div className="perf-trend" title={`Last ${series.length} samples (oldest → newest)`}>
+                      <Sparkline series={series} />
+                      <span className="perf-trend-label">last {series.length} · latest {series[series.length - 1]} ms</span>
+                    </div>
+                  )}
                 </div>
               );
+              const startupSeries = perfHistory?.startup ?? [];
+              const firstTokenSeries = perfHistory?.firstToken ?? [];
               return (
                 <div className="perf-metrics">
-                  <Row title="Startup" stat={perfStats!.startup} />
-                  <Row title="First token (TTFT)" stat={perfStats!.firstToken} />
+                  <Row title="Startup" stat={perfStats!.startup} series={startupSeries} />
+                  <Row title="First token (TTFT)" stat={perfStats!.firstToken} series={firstTokenSeries} />
                 </div>
               );
             })()}

--- a/widget/src/shared/__tests__/sparkline.test.ts
+++ b/widget/src/shared/__tests__/sparkline.test.ts
@@ -1,0 +1,99 @@
+/**
+ * sparkline.test.ts — pure geometry tests for src/shared/sparkline.ts
+ * No DOM/Electron; runs in plain node.
+ */
+import { buildSparkline } from '../sparkline';
+
+describe('buildSparkline — degenerate inputs', () => {
+  test('empty array → no data, empty paths', () => {
+    const g = buildSparkline([]);
+    expect(g.hasData).toBe(false);
+    expect(g.points).toEqual([]);
+    expect(g.linePath).toBe('');
+    expect(g.areaPath).toBe('');
+    expect(g.last).toBeNull();
+    expect(g.min).toBe(0);
+    expect(g.max).toBe(0);
+  });
+
+  test('non-array / junk values are filtered out', () => {
+    // @ts-expect-error intentionally passing junk
+    const g = buildSparkline([NaN, Infinity, undefined, null, 'x']);
+    expect(g.hasData).toBe(false);
+    expect(g.points).toEqual([]);
+  });
+
+  test('mixed finite + junk keeps only finite samples', () => {
+    // @ts-expect-error intentionally passing junk
+    const g = buildSparkline([100, NaN, 200, null, 300]);
+    expect(g.hasData).toBe(true);
+    expect(g.points).toHaveLength(3);
+    expect(g.min).toBe(100);
+    expect(g.max).toBe(300);
+    expect(g.last).toBe(300);
+  });
+
+  test('single sample → centred point + flat full-width line', () => {
+    const g = buildSparkline([500], { width: 120, height: 28, padding: 2 });
+    expect(g.hasData).toBe(true);
+    expect(g.points).toHaveLength(1);
+    expect(g.last).toBe(500);
+    // line should span from left padding to right padding (flat)
+    expect(g.linePath.startsWith('M 2 ')).toBe(true);
+    expect(g.linePath).toContain('L 118 ');
+    // both y-coords equal → flat
+    const ys = g.linePath.match(/[ML] \d+(?:\.\d+)? (\d+(?:\.\d+)?)/g)!;
+    expect(ys.length).toBe(2);
+  });
+
+  test('all-equal samples → flat centred line (no divide-by-zero)', () => {
+    const g = buildSparkline([300, 300, 300], { width: 100, height: 20, padding: 0 });
+    expect(g.hasData).toBe(true);
+    const midY = 10; // height/2 with padding 0
+    expect(g.points.every(p => p.y === midY)).toBe(true);
+  });
+});
+
+describe('buildSparkline — scaling & orientation', () => {
+  test('higher values sit nearer the top (smaller y)', () => {
+    const g = buildSparkline([100, 200], { width: 100, height: 20, padding: 0 });
+    // 200 (max) maps to y=0 (top); 100 (min) maps to y=20 (bottom)
+    expect(g.points[0].y).toBeGreaterThan(g.points[1].y);
+    expect(g.points[1].y).toBe(0);
+    expect(g.points[0].y).toBe(20);
+  });
+
+  test('x positions are evenly spaced left→right', () => {
+    const g = buildSparkline([1, 2, 3], { width: 100, height: 20, padding: 0 });
+    expect(g.points.map(p => p.x)).toEqual([0, 50, 100]);
+  });
+
+  test('last value is the right-most/most-recent sample', () => {
+    const g = buildSparkline([10, 50, 30, 90]);
+    expect(g.last).toBe(90);
+    expect(g.points[g.points.length - 1].x).toBeGreaterThan(g.points[0].x);
+  });
+
+  test('areaPath closes back to the baseline', () => {
+    const g = buildSparkline([1, 2, 3], { width: 100, height: 20, padding: 0 });
+    expect(g.areaPath.endsWith('Z')).toBe(true);
+    // baseline = height - padding = 20
+    expect(g.areaPath).toContain('L 100 20');
+    expect(g.areaPath).toContain('L 0 20');
+  });
+
+  test('respects custom dimensions and defaults', () => {
+    const def = buildSparkline([1, 2]);
+    expect(def.width).toBe(120);
+    expect(def.height).toBe(28);
+    const custom = buildSparkline([1, 2], { width: 200, height: 40 });
+    expect(custom.width).toBe(200);
+    expect(custom.height).toBe(40);
+  });
+
+  test('invalid dimension options fall back to defaults', () => {
+    const g = buildSparkline([1, 2], { width: -5, height: 0 });
+    expect(g.width).toBe(120);
+    expect(g.height).toBe(28);
+  });
+});

--- a/widget/src/shared/sparkline.ts
+++ b/widget/src/shared/sparkline.ts
@@ -1,0 +1,144 @@
+/**
+ * sparkline.ts — pure, dependency-free geometry for the tiny perf trend
+ * sparklines shown in the Settings → Diagnostics & Performance section.
+ *
+ * This module contains ZERO React/DOM/Electron references so it can be unit
+ * tested in plain node. The renderer turns the returned geometry into an inline
+ * <svg>. Keeping the math here means the trickier parts (scaling, the flat-line
+ * degenerate cases, point placement) are covered by fast logic tests instead of
+ * relying on a jsdom render to catch regressions.
+ */
+
+export interface SparklinePoint {
+  x: number;
+  y: number;
+}
+
+export interface SparklineGeometry {
+  /** Computed point coordinates in SVG user units (left->right, chronological). */
+  points: SparklinePoint[];
+  /** Polyline path string for the trend line ("M x y L x y ..."), or '' if empty. */
+  linePath: string;
+  /** Closed path filling the area under the line, or '' if empty. */
+  areaPath: string;
+  width: number;
+  height: number;
+  /** Min value across the series (0 when empty). */
+  min: number;
+  /** Max value across the series (0 when empty). */
+  max: number;
+  /** Most recent (right-most) value, or null when empty. */
+  last: number | null;
+  /** Whether there is at least one finite sample to draw. */
+  hasData: boolean;
+}
+
+export interface SparklineOptions {
+  width?: number;
+  height?: number;
+  /** Inner padding (px) kept clear on every edge so the stroke isn't clipped. */
+  padding?: number;
+}
+
+function round(n: number): number {
+  // Keep paths compact and deterministic for snapshot-style assertions.
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Build sparkline geometry from a chronological list of numbers.
+ *
+ * Degenerate cases are handled explicitly:
+ *   - empty / all-non-finite input  -> hasData=false, empty paths.
+ *   - a single sample               -> one centred point + a short flat line.
+ *   - all-equal samples             -> a flat line centred vertically.
+ *
+ * The series is drawn left->right with the most recent sample on the right,
+ * and y is inverted (larger value = higher on screen = smaller y), which is
+ * the conventional sparkline orientation.
+ */
+export function buildSparkline(
+  values: number[],
+  options: SparklineOptions = {},
+): SparklineGeometry {
+  const width = options.width && options.width > 0 ? options.width : 120;
+  const height = options.height && options.height > 0 ? options.height : 28;
+  const padding = typeof options.padding === 'number' && options.padding >= 0 ? options.padding : 2;
+
+  const clean = (Array.isArray(values) ? values : []).filter(
+    (v): v is number => typeof v === 'number' && Number.isFinite(v),
+  );
+
+  if (clean.length === 0) {
+    return {
+      points: [],
+      linePath: '',
+      areaPath: '',
+      width,
+      height,
+      min: 0,
+      max: 0,
+      last: null,
+      hasData: false,
+    };
+  }
+
+  const min = Math.min(...clean);
+  const max = Math.max(...clean);
+  const last = clean[clean.length - 1]!;
+
+  const innerW = Math.max(0, width - padding * 2);
+  const innerH = Math.max(0, height - padding * 2);
+  const midY = round(padding + innerH / 2);
+
+  // x positions: evenly spaced; a single point sits centred.
+  const xFor = (i: number): number => {
+    if (clean.length === 1) return round(padding + innerW / 2);
+    return round(padding + (innerW * i) / (clean.length - 1));
+  };
+
+  // y positions: invert so higher values sit nearer the top. When every value
+  // is equal (range 0) we draw a flat centred line to avoid divide-by-zero.
+  const range = max - min;
+  const yFor = (v: number): number => {
+    if (range === 0) return midY;
+    const t = (v - min) / range; // 0..1
+    return round(padding + innerH * (1 - t));
+  };
+
+  const points: SparklinePoint[] = clean.map((v, i) => ({ x: xFor(i), y: yFor(v) }));
+
+  // A lone point would produce a zero-length line, so extend it horizontally
+  // across the inner width to read as a flat trend.
+  let linePoints = points;
+  if (points.length === 1) {
+    const p = points[0]!;
+    linePoints = [
+      { x: round(padding), y: p.y },
+      { x: round(width - padding), y: p.y },
+    ];
+  }
+
+  const linePath = linePoints
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`)
+    .join(' ');
+
+  const baseline = round(height - padding);
+  const firstX = linePoints[0]!.x;
+  const lastX = linePoints[linePoints.length - 1]!.x;
+  const areaPath = `${linePath} L ${lastX} ${baseline} L ${firstX} ${baseline} Z`;
+
+  return {
+    points,
+    linePath,
+    areaPath,
+    width,
+    height,
+    min,
+    max,
+    last,
+    hasData: true,
+  };
+}
+
+export default { buildSparkline };

--- a/widget/src/shared/types.ts
+++ b/widget/src/shared/types.ts
@@ -205,6 +205,16 @@ export interface ScheduledJob {
   createdAt: number;
 }
 
+export interface PerfStatSummary {
+  count: number;
+  avg_ms: number;
+  p50_ms: number;
+  p95_ms: number;
+  min_ms: number;
+  max_ms: number;
+  last_ms: number | null;
+}
+
 export interface ElectronAPI {
   sendMessage: (request: HomeBotRequest) => Promise<HomeBotResponse>;
   getSettings: () => Promise<Settings>;
@@ -282,6 +292,9 @@ export interface ElectronAPI {
   resetPermissions?: () => Promise<Settings>;
   // Debug helper exposed for dev/E2E: returns main + renderer log buffers and conversation store snapshot
   readDebugLogs?: () => Promise<{ success: boolean; rendererLogs?: string[]; mainLogs?: string[]; conversationStore?: any; error?: string }>;
+
+  // Diagnostic: baseline perf aggregates (startup + first-token/TTFT) for the Settings Diagnostics section
+  getPerfAggregates?: () => Promise<{ startup: PerfStatSummary; firstToken: PerfStatSummary }>;
   
   // Diagnostic: get env info
   getEnv?: () => Promise<{ isE2E: boolean; isPackagedBuild: boolean; isReleaseBuild: boolean; userDataPath: string }>;

--- a/widget/src/shared/types.ts
+++ b/widget/src/shared/types.ts
@@ -295,6 +295,8 @@ export interface ElectronAPI {
 
   // Diagnostic: baseline perf aggregates (startup + first-token/TTFT) for the Settings Diagnostics section
   getPerfAggregates?: () => Promise<{ startup: PerfStatSummary; firstToken: PerfStatSummary }>;
+  // Diagnostic: recent raw perf samples (chronological) for the Diagnostics trend sparklines
+  getPerfHistory?: (limit?: number) => Promise<{ startup: number[]; firstToken: number[] }>;
   
   // Diagnostic: get env info
   getEnv?: () => Promise<{ isE2E: boolean; isPackagedBuild: boolean; isReleaseBuild: boolean; userDataPath: string }>;


### PR DESCRIPTION
Surfaces the baseline perf metrics in the Settings UI.

- New IPC channel `homebot:get-perf-aggregates` → `readPerfAggregates()`, exposed via preload `getPerfAggregates()` and typed in `shared/types.ts` (`PerfStatSummary`)
- `SettingsPanel` gains a collapsible **Diagnostics & Performance** section showing Startup and First-token (TTFT) **p50/p95 badges** plus avg/min/max/count, an empty-state when no samples exist, and a Refresh button

**Files**
- `widget/src/main/ipc-handlers.ts` — `homebot:get-perf-aggregates` handler
- `widget/src/preload/index.ts` — `getPerfAggregates()` bridge
- `widget/src/shared/types.ts` — `PerfStatSummary`
- `widget/src/renderer/components/SettingsPanel.tsx` — Diagnostics & Performance section
- `widget/src/renderer/__tests__/perf-diagnostics.test.tsx` — badges render, empty-state, refresh re-queries IPC

**Stacked on `feat/baseline-perf-metrics`** (PR base) — review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz)_