### PR TITLE
feat(settings): on-demand System Check in Diagnostics

### DIFF
--- a/widget/src/renderer/__tests__/settings-system-check.test.tsx
+++ b/widget/src/renderer/__tests__/settings-system-check.test.tsx
@@ -1,0 +1,103 @@
+/** @jest-environment jsdom */
+
+import { render, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../components/TelemetryConsentModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/TelemetryDashboard', () => ({ __esModule: true, default: () => null }));
+
+import SettingsPanel from '../components/SettingsPanel';
+
+const baseSettings = {
+  alwaysOnTop: true,
+  n8nUrl: 'http://localhost:5678',
+  widgetHotkey: 'Ctrl+Shift+Space',
+};
+
+const noop = () => {};
+const emptyStat = { count: 0, avg_ms: 0, p50_ms: 0, p95_ms: 0, min_ms: 0, max_ms: 0, last_ms: null };
+
+function baseElectron(runDiagnostics: jest.Mock) {
+  return {
+    getUncensoredMode: jest.fn().mockResolvedValue({ enabled: false }),
+    mcpListServers: jest.fn().mockResolvedValue([]),
+    mcpGetStatus: jest.fn().mockResolvedValue([]),
+    schedulerList: jest.fn().mockResolvedValue([]),
+    listOllamaModels: jest.fn().mockResolvedValue({ success: true, models: [] }),
+    getPerfAggregates: jest.fn().mockResolvedValue({ startup: { ...emptyStat }, firstToken: { ...emptyStat } }),
+    getPerfHistory: jest.fn().mockResolvedValue({ startup: [], firstToken: [] }),
+    runDiagnostics,
+  };
+}
+
+function expandSection(container: HTMLElement, label: string) {
+  const toggles = Array.from(container.querySelectorAll('.sp-section-toggle'));
+  const btn = toggles.find(t => t.textContent?.includes(label)) as HTMLElement | undefined;
+  if (btn && btn.textContent?.includes('▸')) fireEvent.click(btn);
+}
+
+const sampleReport = {
+  disk: { freeGB: 42.5, ok: true, warning: null },
+  ollama: { reachable: true, url: 'http://localhost:11434', statusCode: 200, latencyMs: 12 },
+  n8n: { reachable: false, url: 'http://localhost:5678', statusCode: null, latencyMs: null },
+  qdrant: { reachable: true, url: 'http://localhost:6333', statusCode: 200, latencyMs: 8 },
+  permissions: { canWrite: true, path: '/userData' },
+  hardware: { vramGB: 8, gpuName: 'NVIDIA RTX 4060', profile: '8gb' },
+  durationMs: 120,
+  timestamp: new Date('2026-06-30T00:00:00Z').toISOString(),
+};
+
+describe('SettingsPanel — System check', () => {
+  afterEach(() => {
+    delete (window as any).electron;
+    jest.clearAllMocks();
+  });
+
+  function findInSysCheckGroup(container: HTMLElement, label: string) {
+    const group = Array.from(container.querySelectorAll('.setting-group'))
+      .find(g => g.textContent?.includes('System check')) as HTMLElement | undefined;
+    return Array.from(group?.querySelectorAll('button') ?? [])
+      .find(b => b.textContent?.includes(label)) as HTMLButtonElement | undefined;
+  }
+
+  test('runs diagnostics on click and renders each check', async () => {
+    const runDiagnostics = jest.fn().mockResolvedValue(sampleReport);
+    (window as any).electron = baseElectron(runDiagnostics);
+
+    const { container } = render(
+      <SettingsPanel settings={baseSettings as any} onSave={noop} onClose={noop} />
+    );
+    expandSection(container, 'Diagnostics');
+
+    const runBtn = findInSysCheckGroup(container, 'Run system check');
+    expect(runBtn).toBeTruthy();
+    fireEvent.click(runBtn!);
+
+    await waitFor(() => expect(runDiagnostics).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const text = container.textContent || '';
+      expect(text).toContain('42.5 GB free');
+      expect(text).toContain('Ollama');
+      expect(text).toContain('online (12 ms)');
+      expect(text).toContain('n8n');
+      expect(text).toContain('offline');
+      expect(text).toContain('NVIDIA RTX 4060');
+    });
+
+    // Button flips to a re-run label once results are present
+    await waitFor(() => expect(findInSysCheckGroup(container, 'Re-run system check')).toBeTruthy());
+  });
+
+  test('shows an error when the diagnostics IPC is unavailable', async () => {
+    const runDiagnostics = jest.fn().mockResolvedValue(undefined);
+    (window as any).electron = baseElectron(runDiagnostics);
+
+    const { container } = render(
+      <SettingsPanel settings={baseSettings as any} onSave={noop} onClose={noop} />
+    );
+    expandSection(container, 'Diagnostics');
+
+    fireEvent.click(findInSysCheckGroup(container, 'Run system check')!);
+
+    await waitFor(() => expect(container.textContent).toContain('System check is unavailable'));
+  });
+});

--- a/widget/src/renderer/components/SettingsPanel.tsx
+++ b/widget/src/renderer/components/SettingsPanel.tsx
@@ -212,6 +212,35 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openSections.diagnostics]);
 
+  // System check: on-demand re-run of the first-run environment diagnostics
+  // (disk / Ollama / n8n / Qdrant / write-permissions / GPU). Reuses the
+  // existing `homebot:run-diagnostics` IPC — renderer-only, no main changes.
+  type SysCheckReport = {
+    disk: { freeGB: number | null; ok: boolean; warning: string | null };
+    ollama: { reachable: boolean; latencyMs: number | null };
+    n8n: { reachable: boolean; latencyMs: number | null };
+    qdrant: { reachable: boolean; latencyMs: number | null };
+    permissions: { canWrite: boolean };
+    hardware: { vramGB: number | null; gpuName: string | null; profile: string | null };
+    timestamp: string;
+  };
+  const [sysCheck, setSysCheck] = useState<SysCheckReport | null>(null);
+  const [sysCheckLoading, setSysCheckLoading] = useState(false);
+  const [sysCheckError, setSysCheckError] = useState<string | null>(null);
+  const runSystemCheck = async () => {
+    setSysCheckLoading(true);
+    setSysCheckError(null);
+    try {
+      const r = await (window as any).electron?.runDiagnostics?.();
+      if (r) setSysCheck(r as SysCheckReport);
+      else setSysCheckError('System check is unavailable on this build.');
+    } catch (e: any) {
+      setSysCheckError(e?.message || 'System check failed.');
+    } finally {
+      setSysCheckLoading(false);
+    }
+  };
+
   // Fetch installed Ollama models on mount
   useEffect(() => {
     window.electron?.listOllamaModels?.().then(res => {
@@ -2111,6 +2140,38 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             })()}
             <button type="button" className="button button-cancel" style={{ marginTop: 8 }} onClick={() => { void loadPerfStats(); }} disabled={perfLoading}>
               {perfLoading ? 'Refreshing\u2026' : 'Refresh'}
+            </button>
+          </div>
+
+          <div className="setting-group">
+            <label className="setting-label">\ud83e\ude7a System check</label>
+            <small className="setting-hint">Re-run the first-run environment checks on demand: disk space, Ollama / n8n / Qdrant reachability, write permissions, and detected GPU.</small>
+            {sysCheckError && <div className="perf-empty">{sysCheckError}</div>}
+            {sysCheck && (() => {
+              const dotColor = (ok: boolean | null) => ok === null ? '#8b949e' : ok ? '#3fb950' : '#f85149';
+              const Item = ({ label, ok, detail }: { label: string; ok: boolean | null; detail?: string }) => (
+                <div className="syscheck-row" style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, padding: '2px 0' }}>
+                  <span aria-hidden="true" style={{ width: 9, height: 9, borderRadius: '50%', flex: '0 0 auto', background: dotColor(ok), display: 'inline-block' }} />
+                  <span style={{ fontWeight: 600 }}>{label}</span>
+                  {detail && <span style={{ opacity: 0.8 }}>\u2014 {detail}</span>}
+                </div>
+              );
+              const svc = (s: { reachable: boolean; latencyMs: number | null }) =>
+                s.reachable ? `online${s.latencyMs != null ? ` (${s.latencyMs} ms)` : ''}` : 'offline';
+              return (
+                <div className="syscheck-results" style={{ marginTop: 6 }}>
+                  <Item label="Disk space" ok={sysCheck.disk.ok} detail={sysCheck.disk.freeGB != null ? `${sysCheck.disk.freeGB.toFixed(1)} GB free${sysCheck.disk.warning ? ` \u2014 ${sysCheck.disk.warning}` : ''}` : 'unknown'} />
+                  <Item label="Ollama" ok={sysCheck.ollama.reachable} detail={svc(sysCheck.ollama)} />
+                  <Item label="n8n" ok={sysCheck.n8n.reachable} detail={svc(sysCheck.n8n)} />
+                  <Item label="Qdrant" ok={sysCheck.qdrant.reachable} detail={svc(sysCheck.qdrant)} />
+                  <Item label="Write permissions" ok={sysCheck.permissions.canWrite} detail={sysCheck.permissions.canWrite ? 'OK' : 'cannot write to userData'} />
+                  <Item label="GPU" ok={sysCheck.hardware.vramGB != null ? true : null} detail={sysCheck.hardware.vramGB != null ? `${sysCheck.hardware.gpuName ?? 'GPU'} \u00b7 ${sysCheck.hardware.vramGB} GB${sysCheck.hardware.profile ? ` \u00b7 ${sysCheck.hardware.profile}` : ''}` : 'not detected'} />
+                  <small className="setting-hint" style={{ display: 'block', marginTop: 4 }}>Last run: {new Date(sysCheck.timestamp).toLocaleTimeString()}</small>
+                </div>
+              );
+            })()}
+            <button type="button" className="button button-cancel" style={{ marginTop: 8 }} onClick={() => { void runSystemCheck(); }} disabled={sysCheckLoading}>
+              {sysCheckLoading ? 'Checking\u2026' : (sysCheck ? 'Re-run system check' : 'Run system check')}
             </button>
           </div>
         </>}


### PR DESCRIPTION
## What
Adds a **System check** panel to **Settings → Diagnostics & Performance** that re-runs the first-run environment diagnostics on demand.

Until now those checks (disk space, Ollama / n8n / Qdrant reachability, write permissions, GPU/VRAM) ran **only once**, inside `FirstRunModal`. This surfaces them in Settings so a user can re-verify their environment anytime — e.g. Ollama was stopped, a port got blocked, or the disk filled up — without reinstalling or wiping config.

## How
- **Renderer-only.** Reuses the existing `homebot:run-diagnostics` IPC (preload `runDiagnostics()`) that already backs first-run. No main/preload/type changes.
- Colour-coded per-check rows (🟢 ok / 🔴 problem / ⚪ unknown), service latency, detected GPU + hardware profile, and a last-run timestamp. Button flips between **Run system check** / **Re-run system check** and disables while running.
- Defensive: shows an inline message if the IPC is unavailable or throws (mirrors how `FirstRunModal` treats it as non-critical).

## Tests
- `settings-system-check.test.tsx` (jsdom): runs diagnostics on click and asserts each check renders (disk free, Ollama online + latency, n8n offline, GPU name), the button flips to "Re-run", plus an unavailable-IPC error path.
- Verified locally: `tsc --noEmit` adds **zero** new type errors (only the pre-existing `preload sdCppStatus`); `settings-system-check` + `perf-diagnostics` suites pass (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz)_