### PR TITLE
feat(settings): "Copy support report" in Diagnostics

### DIFF
--- a/widget/src/renderer/components/SettingsPanel.tsx
+++ b/widget/src/renderer/components/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import TelemetryDashboard from './TelemetryDashboard';
 import type { Settings as SharedSettings, CustomLLMConfig, CustomModelInfo, ScheduledJob, PerfStatSummary } from '../../shared/types';
 import { buildSparkline } from '../../shared/sparkline';
 import { buildPerfAdvice } from '../../shared/perf-advice';
+import { buildSupportReport } from '../../shared/support-report';
 
 interface Settings {
   alwaysOnTop: boolean;
@@ -238,6 +239,25 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
       setSysCheckError(e?.message || 'System check failed.');
     } finally {
       setSysCheckLoading(false);
+    }
+  };
+
+  // Copy a combined diagnostics "support report" (perf + system check + env)
+  // to the clipboard so users can paste a full snapshot when reporting issues.
+  const [reportCopied, setReportCopied] = useState(false);
+  const copySupportReport = async () => {
+    const report = buildSupportReport({
+      generatedAt: new Date().toISOString(),
+      platform: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+      perf: perfStats,
+      systemCheck: sysCheck,
+    });
+    try {
+      await navigator.clipboard.writeText(report);
+      setReportCopied(true);
+      setTimeout(() => setReportCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable — non-critical */
     }
   };
 
@@ -2172,6 +2192,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             })()}
             <button type="button" className="button button-cancel" style={{ marginTop: 8 }} onClick={() => { void runSystemCheck(); }} disabled={sysCheckLoading}>
               {sysCheckLoading ? 'Checking\u2026' : (sysCheck ? 'Re-run system check' : 'Run system check')}
+            </button>
+            <button type="button" className="button button-cancel" style={{ marginTop: 8, marginLeft: 8 }} onClick={() => { void copySupportReport(); }} title="Copy a diagnostics snapshot (performance + system check + environment) to the clipboard">
+              {reportCopied ? '\u2713 Copied' : '\ud83d\udccb Copy support report'}
             </button>
           </div>
         </>}

--- a/widget/src/shared/__tests__/support-report.test.ts
+++ b/widget/src/shared/__tests__/support-report.test.ts
@@ -1,0 +1,69 @@
+import { buildSupportReport, SupportReportInput } from '../support-report';
+
+const stat = (over: Partial<any> = {}) => ({
+  count: 5, avg_ms: 1000, p50_ms: 900, p95_ms: 1500, min_ms: 800, max_ms: 1600, last_ms: 1200, ...over,
+});
+
+const fullSystemCheck = {
+  disk: { freeGB: 42.5, ok: true, warning: null },
+  ollama: { reachable: true, latencyMs: 12 },
+  n8n: { reachable: false, latencyMs: null },
+  qdrant: { reachable: true, latencyMs: 8 },
+  permissions: { canWrite: true },
+  hardware: { vramGB: 8, gpuName: 'NVIDIA RTX 4060', profile: '8gb' },
+  timestamp: '2026-06-30T00:00:00.000Z',
+};
+
+describe('buildSupportReport', () => {
+  test('includes header, perf p95, and system-check details', () => {
+    const input: SupportReportInput = {
+      generatedAt: '2026-06-30T01:00:00.000Z',
+      appVersion: '1.1.0',
+      platform: 'Test/1.0',
+      perf: { startup: stat(), firstToken: stat({ p95_ms: 450, p50_ms: 300, count: 3 }) },
+      systemCheck: fullSystemCheck,
+    };
+    const out = buildSupportReport(input);
+
+    expect(out).toContain('# HomeBot — Support Report');
+    expect(out).toContain('App version: 1.1.0');
+    expect(out).toContain('Platform: Test/1.0');
+    // perf
+    expect(out).toContain('Startup: p50 900 ms · p95 1500 ms');
+    expect(out).toContain('First token (TTFT): p50 300 ms · p95 450 ms');
+    // system check
+    expect(out).toContain('Disk: 42.5 GB free');
+    expect(out).toContain('Ollama: online (12 ms)');
+    expect(out).toContain('n8n: offline');
+    expect(out).toContain('Write permissions: OK');
+    expect(out).toContain('GPU: NVIDIA RTX 4060 · 8 GB · 8gb');
+  });
+
+  test('handles missing perf and system check gracefully', () => {
+    const out = buildSupportReport({ generatedAt: 'now' });
+    expect(out).toContain('No performance samples recorded yet.');
+    expect(out).toContain('Not run. Use "Run system check"');
+    expect(out).toContain('App version: unknown');
+    expect(out).toContain('Platform: unknown');
+  });
+
+  test('treats zero-sample perf as no data', () => {
+    const empty = stat({ count: 0 });
+    const out = buildSupportReport({ perf: { startup: empty, firstToken: empty } });
+    expect(out).toContain('No performance samples recorded yet.');
+  });
+
+  test('flags low disk and missing write permission', () => {
+    const out = buildSupportReport({
+      systemCheck: {
+        ...fullSystemCheck,
+        disk: { freeGB: 2.1, ok: false, warning: 'Low disk space' },
+        permissions: { canWrite: false },
+        hardware: { vramGB: null, gpuName: null, profile: null },
+      },
+    });
+    expect(out).toContain('Disk: 2.1 GB free (LOW) — Low disk space');
+    expect(out).toContain('Write permissions: CANNOT WRITE');
+    expect(out).toContain('GPU: not detected');
+  });
+});

--- a/widget/src/shared/support-report.ts
+++ b/widget/src/shared/support-report.ts
@@ -1,0 +1,85 @@
+import type { PerfStatSummary } from './types';
+
+/**
+ * Pure builder for a copy-pasteable diagnostics "support report".
+ *
+ * Combines the locally-collected perf aggregates and the on-demand system
+ * check into a single Markdown block so a user can paste a complete snapshot
+ * of their environment when reporting an issue. No DOM / Electron access —
+ * the caller supplies the data, which keeps this unit-testable.
+ */
+
+export interface SupportReportService {
+  reachable: boolean;
+  latencyMs: number | null;
+}
+
+export interface SupportReportSystemCheck {
+  disk: { freeGB: number | null; ok: boolean; warning: string | null };
+  ollama: SupportReportService;
+  n8n: SupportReportService;
+  qdrant: SupportReportService;
+  permissions: { canWrite: boolean };
+  hardware: { vramGB: number | null; gpuName: string | null; profile: string | null };
+  timestamp: string;
+}
+
+export interface SupportReportInput {
+  generatedAt?: string;
+  appVersion?: string | null;
+  platform?: string | null;
+  perf?: { startup: PerfStatSummary; firstToken: PerfStatSummary } | null;
+  systemCheck?: SupportReportSystemCheck | null;
+}
+
+function fmtMs(n: number | null | undefined): string {
+  return n === null || n === undefined ? 'n/a' : `${Math.round(n)} ms`;
+}
+
+function serviceLine(label: string, s?: SupportReportService): string {
+  if (!s) return `- ${label}: not checked`;
+  const latency = s.latencyMs != null ? ` (${Math.round(s.latencyMs)} ms)` : '';
+  return `- ${label}: ${s.reachable ? 'online' : 'offline'}${latency}`;
+}
+
+export function buildSupportReport(input: SupportReportInput): string {
+  const lines: string[] = [];
+  lines.push('# HomeBot — Support Report');
+  lines.push('');
+  lines.push(`- Generated: ${input.generatedAt ?? 'unknown'}`);
+  lines.push(`- App version: ${input.appVersion ?? 'unknown'}`);
+  lines.push(`- Platform: ${input.platform ?? 'unknown'}`);
+  lines.push('');
+
+  lines.push('## Performance');
+  if (input.perf && (input.perf.startup.count > 0 || input.perf.firstToken.count > 0)) {
+    const row = (label: string, s: PerfStatSummary) =>
+      `- ${label}: p50 ${fmtMs(s.p50_ms)} · p95 ${fmtMs(s.p95_ms)} · avg ${fmtMs(s.avg_ms)} (n=${s.count})`;
+    lines.push(row('Startup', input.perf.startup));
+    lines.push(row('First token (TTFT)', input.perf.firstToken));
+  } else {
+    lines.push('- No performance samples recorded yet.');
+  }
+  lines.push('');
+
+  lines.push('## System check');
+  const sc = input.systemCheck;
+  if (sc) {
+    lines.push(`- Last run: ${sc.timestamp}`);
+    const disk = sc.disk.freeGB != null ? `${sc.disk.freeGB.toFixed(1)} GB free` : 'unknown';
+    lines.push(`- Disk: ${disk}${sc.disk.ok ? '' : ' (LOW)'}${sc.disk.warning ? ` — ${sc.disk.warning}` : ''}`);
+    lines.push(serviceLine('Ollama', sc.ollama));
+    lines.push(serviceLine('n8n', sc.n8n));
+    lines.push(serviceLine('Qdrant', sc.qdrant));
+    lines.push(`- Write permissions: ${sc.permissions.canWrite ? 'OK' : 'CANNOT WRITE'}`);
+    const gpu = sc.hardware.vramGB != null
+      ? `${sc.hardware.gpuName ?? 'GPU'} · ${sc.hardware.vramGB} GB${sc.hardware.profile ? ` · ${sc.hardware.profile}` : ''}`
+      : 'not detected';
+    lines.push(`- GPU: ${gpu}`);
+  } else {
+    lines.push('- Not run. Use "Run system check" in Settings → Diagnostics first.');
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## What
Adds a **"📋 Copy support report"** button to Settings → Diagnostics & Performance. One click copies a Markdown snapshot of the user's environment to the clipboard:
- **Performance** — p50/p95/avg for startup + first-token (TTFT)
- **System check** — disk, Ollama / n8n / Qdrant, write permissions, GPU (from the on-demand check added in #27)
- **Environment** — platform + timestamp

So when something's wrong, a user (or the capstone supervisor) can paste a complete picture instead of describing it piecemeal.

## How
- New **pure** module `shared/support-report.ts` (`buildSupportReport`) — no DOM/Electron access, the caller passes data in. That keeps it fully unit-testable.
- `SettingsPanel`: button beside "Run system check"; builds the report from the already-loaded perf + system-check state + `navigator` info, copies via the clipboard API, shows "✓ Copied".

## Tests / verification (local)
- `support-report.test.ts`: full report, missing perf/system-check, zero-sample perf, and low-disk + no-write-permission paths.
- `tsc` adds no new errors (only the pre-existing `preload sdCppStatus`); **ESLint clean** (0 errors — passes the new react-hooks gate); jest **6/6** (support-report + settings-system-check).

Builds on #27 (System Check) and the perf metrics already on main; renderer + shared only, no main/preload changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz)_