### PR TITLE
test(e2e): deterministic first-run wizard under E2E (fix flaky specs)

### DIFF
--- a/widget/src/renderer/components/FirstRunModal.tsx
+++ b/widget/src/renderer/components/FirstRunModal.tsx
@@ -199,6 +199,21 @@ export default function FirstRunModal({
     setDiskOk(true);
     detectHardware();
 
+    // E2E: skip the real Ollama detection. With no Ollama present,
+    // checkConnection / checkOllamaInstalled / startOllama each run their full
+    // network/spawn timeouts, which left the footer button stuck on "Setting
+    // up…" well past the test's click timeout and flaked the first-run specs.
+    // Jump straight to a deterministic terminal phase so "Continue anyway" is
+    // immediately available. (diskOk stays true from above so the button isn't
+    // gated on disk.)
+    try {
+      const env = await (window as any).electron?.getEnv?.();
+      if (env?.isE2E) {
+        setLocalPhase('ollama-missing');
+        return;
+      }
+    } catch { /* fall through to real detection */ }
+
     // Check disk space before potentially pulling large models
     try {
       const diagResult = await (window as any).electron.runDiagnostics?.();


### PR DESCRIPTION
## Problem
The first-run specs (`first-run.e2e.spec.ts:28` and `:84`) were the most-cited flakes. After choosing "Local (Ollama)", `runLocalSetup` runs the **real** detection — `checkConnection` → `checkOllamaInstalled` → `startOllama` — and with no Ollama present (always true in CI) each burns its full network/spawn timeout. The footer button stays **"Setting up…"** the whole time, so `completeFirstRunWizard`'s click on "Continue anyway" intermittently timed out.

## Fix
Short-circuit detection when `getEnv().isE2E`: jump straight to the `ollama-missing` terminal phase (with `diskOk` left true), so **"Continue anyway" is immediately available** and the wizard is deterministic. Production behaviour is unchanged — the branch only runs under `HOMEBOT_E2E`.

## Verification (local)
- `tsc` clean (only the pre-existing `preload sdCppStatus`); **ESLint clean** (0 errors); **first-run-modal unit tests 20/20**.
- e2e behaviour validated by this PR's CI run.

## Scope (honest)
This **deterministically** fixes the first-run flakes. The other intermittent specs — `permission-flow` (15/150) and `settings-panel` "closes on Escape" (78) — seed config (skip the wizard) and have **no deterministic bug**; they're load-sensitivity in the **sequential** docker `playwright-e2e.yml` run (full suite, `workers:1`), already covered by `retries: 1` + the workflow's 3-attempt loop. Hardening those further needs their captured traces — a separate follow-up rather than a speculative change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz

---
_Generated by [Claude Code](https://claude.ai/code/session_012FYfoBsmpaRq3hxCXJm3Vz)_