### PR TITLE
feat: Pro upgrade UX — license activation, feature gating, upgrade modal

### DIFF
--- a/src/__tests__/gating.test.ts
+++ b/src/__tests__/gating.test.ts
@@ -97,20 +97,20 @@ describe('Automation Center — handler/IPC gate', () => {
   const proTier = () => 'pro' as const;
 
   test('channel registry maps channels to capabilities', () => {
-    expect(isAutomationChannel('homebot:automation:scheduler:add')).toBe(true);
+    expect(isAutomationChannel('homebot:scheduler-add')).toBe(true);
     expect(isAutomationChannel('homebot:get-settings')).toBe(false);
     expect(capabilityForChannel('homebot:automation:image:generate')).toBe('imageGen');
-    expect(capabilityForChannel('homebot:automation:workflow:create')).toBe('automation');
+    expect(capabilityForChannel('homebot:scheduler-add')).toBe('automation');
     expect(Object.keys(AUTOMATION_CENTER_CHANNELS).length).toBeGreaterThanOrEqual(5);
   });
 
   test('guardAutomationChannel blocks free, allows pro', async () => {
-    const blocked = await guardAutomationChannel('homebot:automation:scheduler:add', freeTier);
+    const blocked = await guardAutomationChannel('homebot:scheduler-add', freeTier);
     expect(blocked).not.toBeNull();
     expect(isGateBlocked(blocked)).toBe(true);
     expect(blocked?.upgrade.capability).toBe('automation');
 
-    const allowed = await guardAutomationChannel('homebot:automation:scheduler:add', proTier);
+    const allowed = await guardAutomationChannel('homebot:scheduler-add', proTier);
     expect(allowed).toBeNull();
   });
 
@@ -124,12 +124,12 @@ describe('Automation Center — handler/IPC gate', () => {
       ran++;
       return { ok: true, job };
     };
-    const freeWrapped = gatedAutomationHandler('homebot:automation:scheduler:add', freeTier, handler);
+    const freeWrapped = gatedAutomationHandler('homebot:scheduler-add', freeTier, handler);
     const res1 = await freeWrapped({}, { name: 'daily' });
     expect(isGateBlocked(res1)).toBe(true);
     expect(ran).toBe(0); // real handler never executed for free user
 
-    const proWrapped = gatedAutomationHandler('homebot:automation:scheduler:add', proTier, handler);
+    const proWrapped = gatedAutomationHandler('homebot:scheduler-add', proTier, handler);
     const res2 = await proWrapped({}, { name: 'daily' });
     expect(isGateBlocked(res2)).toBe(false);
     expect((res2 as any).ok).toBe(true);

--- a/src/handlers/automationCenter.ts
+++ b/src/handlers/automationCenter.ts
@@ -6,10 +6,10 @@
  * proactive/briefing and local-image-generation surfaces that depend on it.
  *
  * In the running app these are exposed as ipcMain.handle channels in
- * widget/src/main/ipc-handlers.ts, e.g.:
+ * widget/src/main/ipc-handlers.ts — the literal channel strings registered
+ * there, e.g.:
  *   - 'homebot:automation:image:generate'   (sd.cpp image gen)   → imageGen
- *   - scheduler jobs: addJob/removeJob/toggleJob/listJobs        → automation
- *   - n8n workflow create/activate                               → automation
+ *   - 'homebot:scheduler-list'/-add/-remove/-toggle               → automation
  *
  * This module enumerates those channels, maps each to the capability that
  * unlocks it, and provides a single guard + a helper to register pre-gated
@@ -26,16 +26,15 @@ import {
 /**
  * Automation Center IPC channels → required capability.
  * Listing them in one place means adding a new automation channel is a
- * one-line addition that is automatically fenced.
+ * one-line addition that is automatically fenced. Keys mirror the literal
+ * channel names registered in widget/src/main/ipc-handlers.ts.
  */
 export const AUTOMATION_CENTER_CHANNELS: Readonly<Record<string, Capability>> = {
   'homebot:automation:image:generate': 'imageGen',
-  'homebot:automation:scheduler:list': 'automation',
-  'homebot:automation:scheduler:add': 'automation',
-  'homebot:automation:scheduler:remove': 'automation',
-  'homebot:automation:scheduler:toggle': 'automation',
-  'homebot:automation:workflow:create': 'automation',
-  'homebot:automation:workflow:activate': 'automation',
+  'homebot:scheduler-list': 'automation',
+  'homebot:scheduler-add': 'automation',
+  'homebot:scheduler-remove': 'automation',
+  'homebot:scheduler-toggle': 'automation',
 };
 
 /** Is this IPC channel part of the (Pro-gated) Automation Center? */
@@ -74,8 +73,8 @@ export async function guardAutomationChannel(
  *   import { addJob } from './scheduler';
  *
  *   ipcMain.handle(
- *     'homebot:automation:scheduler:add',
- *     gatedAutomationHandler('homebot:automation:scheduler:add', getCurrentTier,
+ *     'homebot:scheduler-add',
+ *     gatedAutomationHandler('homebot:scheduler-add', getCurrentTier,
  *       async (_event, job) => addJob(job))
  *   );
  *

--- a/widget/src/main/__tests__/licensing.test.ts
+++ b/widget/src/main/__tests__/licensing.test.ts
@@ -1,0 +1,93 @@
+import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+
+// Mock electron app.getPath to return a temp dir, same pattern as config-manager.test.ts
+jest.mock('electron', () => ({
+  app: {
+    getPath: jest.fn(() => process.env.TEST_USERDATA || ''),
+  },
+}));
+
+import {
+  getCurrentTier,
+  getLicenseStatus,
+  activateLicense,
+  validateLicense,
+  deactivateLicense,
+} from '../licensing';
+
+describe('main-process licensing wiring', () => {
+  const temp = join(os.tmpdir(), 'homebot-license-test-' + Date.now());
+
+  beforeEach(() => {
+    process.env.TEST_USERDATA = temp;
+    if (existsSync(temp)) rmSync(temp, { recursive: true, force: true });
+    mkdirSync(temp, { recursive: true });
+    delete process.env.LEMONSQUEEZY_API_KEY;
+    delete process.env.LEMONSQUEEZY_STORE_ID;
+  });
+
+  afterAll(() => {
+    try { rmSync(temp, { recursive: true, force: true }); } catch {}
+  });
+
+  test('no license on disk → Free tier, hasLicense false', () => {
+    expect(getCurrentTier()).toBe('free');
+    const status = getLicenseStatus();
+    expect(status.tier).toBe('free');
+    expect(status.hasLicense).toBe(false);
+  });
+
+  test('activate without Lemon Squeezy configured returns a graceful not-configured error', async () => {
+    const result = await activateLicense('SOME-KEY');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/not configured/i);
+    expect(getCurrentTier()).toBe('free');
+  });
+
+  test('activate with a fake configured fetch persists a Pro cache and flips the tier', async () => {
+    process.env.LEMONSQUEEZY_API_KEY = 'test-key';
+    process.env.LEMONSQUEEZY_STORE_ID = '123';
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        activated: true,
+        instance: { id: 'inst-1' },
+        license_key: { status: 'active', activation_usage: 1, activation_limit: 5, expires_at: null },
+      }),
+    })) as any;
+
+    try {
+      const result = await activateLicense('REAL-KEY');
+      expect(result.valid).toBe(true);
+      expect(getCurrentTier()).toBe('pro');
+
+      const status = getLicenseStatus();
+      expect(status.tier).toBe('pro');
+      expect(status.hasLicense).toBe(true);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  test('validateLicense with no prior activation reports an error and stays Free', async () => {
+    const result = await validateLicense();
+    expect(result.valid).toBe(false);
+    expect(getCurrentTier()).toBe('free');
+  });
+
+  test('deactivateLicense clears the stored state even with no instance id', async () => {
+    const result = await deactivateLicense();
+    expect(result.valid).toBe(true);
+    expect(getCurrentTier()).toBe('free');
+    expect(getLicenseStatus().hasLicense).toBe(false);
+  });
+
+  test('a corrupt license.json on disk is treated as no license (free)', () => {
+    writeFileSync(join(temp, 'license.json'), '{not json', 'utf-8');
+    expect(getCurrentTier()).toBe('free');
+  });
+});

--- a/widget/src/main/ipc-handlers.ts
+++ b/widget/src/main/ipc-handlers.ts
@@ -55,6 +55,14 @@ import { isDevelopment, isDemoMode } from './env';
 import { homebotWebhookHeaders } from './webhook-auth';
 import { logTelemetryEvent, readToolCallAggregates } from './utils/logger';
 import { createAndActivateWorkflow, ensureWebFetchWorkflow } from './n8n-api';
+import { gatedAutomationHandler } from '../../../src/handlers/automationCenter';
+import {
+  getCurrentTier,
+  getLicenseStatus,
+  activateLicense,
+  validateLicense,
+  deactivateLicense,
+} from './licensing';
 
 function normalizeOllamaBaseUrl(raw?: string): string {
   const input = (raw || DEFAULT_OLLAMA_URL).trim();
@@ -310,7 +318,11 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
   });
 
   // Image generation panel: delegates to the same tool handler used in chat
-  ipcMain.handle('homebot:automation:image:generate', async (_event, { payload }) => {
+  // Pro-gated (imageGen) — free users get a structured upgrade_required response.
+  ipcMain.handle('homebot:automation:image:generate', gatedAutomationHandler(
+    'homebot:automation:image:generate',
+    getCurrentTier,
+    async (_event, { payload }) => {
     const rawPrompt = String(payload?.prompt || '').trim();
     // Parse resolution string (e.g. '512x512') into width/height
     let width = 512, height = 512;
@@ -386,7 +398,7 @@ export function registerIpcHandlers(mainWindow?: BrowserWindow): void {
         }
       };
     }
-  });
+  }));
 
   // sd-cpp local image generation status & setup
   ipcMain.handle('homebot:sd-cpp:status', async () => {
@@ -1389,10 +1401,13 @@ try {
     });
   });
 
-  // ── Scheduler ──────────────────────────────────────────────────────────────────
-  ipcMain.handle('homebot:scheduler-list', () => listJobs());
+  // ── Scheduler (Pro-gated: 'automation') ──────────────────────────────────────
+  ipcMain.handle('homebot:scheduler-list', gatedAutomationHandler(
+    'homebot:scheduler-list', getCurrentTier, async () => listJobs()
+  ));
 
-  ipcMain.handle('homebot:scheduler-add', (_event, input: any) => {
+  ipcMain.handle('homebot:scheduler-add', gatedAutomationHandler(
+    'homebot:scheduler-add', getCurrentTier, async (_event, input: any) => {
     const { name, message, intervalMinutes, dailyTime, enabled } = input || {};
     if (!name || !message) return { success: false, error: 'name and message are required' };
     const job = addJob({
@@ -1403,16 +1418,32 @@ try {
       enabled: enabled !== false,
     });
     return { success: true, job };
-  });
+  }));
 
-  ipcMain.handle('homebot:scheduler-remove', (_event, id: string) => {
+  ipcMain.handle('homebot:scheduler-remove', gatedAutomationHandler(
+    'homebot:scheduler-remove', getCurrentTier, async (_event, id: string) => {
     return { success: removeJob(id) };
-  });
+  }));
 
-  ipcMain.handle('homebot:scheduler-toggle', (_event, id: string, enabled: boolean) => {
+  ipcMain.handle('homebot:scheduler-toggle', gatedAutomationHandler(
+    'homebot:scheduler-toggle', getCurrentTier, async (_event, id: string, enabled: boolean) => {
     const job = toggleJob(id, enabled);
     return job ? { success: true, job } : { success: false, error: 'Job not found' };
+  }));
+
+  // ── Licensing (Pro entitlement) ───────────────────────────────────────────────
+  ipcMain.handle('homebot:license:status', async () => getLicenseStatus());
+
+  ipcMain.handle('homebot:license:activate', async (_event, licenseKey: string) => {
+    if (!licenseKey || !String(licenseKey).trim()) {
+      return { valid: false, error: 'License key is required' };
+    }
+    return activateLicense(String(licenseKey));
   });
+
+  ipcMain.handle('homebot:license:validate', async () => validateLicense());
+
+  ipcMain.handle('homebot:license:deactivate', async () => deactivateLicense());
 
   // ── TTS (text-to-speech) ────────────────────────────────────────────────────
   // Uses Edge TTS neural voices (msedge-tts), falls back to Web Speech API

--- a/widget/src/main/licensing.ts
+++ b/widget/src/main/licensing.ts
@@ -1,0 +1,107 @@
+/**
+ * SADIE / HomeBot — main-process wiring for Pro licensing.
+ * ---------------------------------------------------------------------------
+ * Bridges the pure, electron-agnostic modules in repo-root `src/licensing` and
+ * `src/entitlements` to the actual app: persists the CachedEntitlement +
+ * activated license to a plain JSON file in userData (same pattern as
+ * settings/automations/quiz-progress elsewhere in this file), and exposes a
+ * TierProvider (getCurrentTier) consumed by the gated IPC handlers.
+ */
+import { app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  loadLemonSqueezyConfig,
+  LemonSqueezyLicenseService,
+  type CachedEntitlement,
+  resolveTier,
+} from '../../../src/licensing';
+import { Tier, DEFAULT_UPGRADE_URL } from '../../../src/entitlements';
+import type { LicenseValidationResult } from '../../../src/licensing/types';
+
+interface StoredLicenseState {
+  licenseKey?: string;
+  instanceId?: string;
+  cache?: CachedEntitlement;
+}
+
+function licenseFilePath(): string {
+  return path.join(app.getPath('userData'), 'license.json');
+}
+
+function loadState(): StoredLicenseState {
+  try {
+    const raw = fs.readFileSync(licenseFilePath(), 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function saveState(state: StoredLicenseState): void {
+  fs.writeFileSync(licenseFilePath(), JSON.stringify(state, null, 2), 'utf-8');
+}
+
+function service(): LemonSqueezyLicenseService {
+  return new LemonSqueezyLicenseService(loadLemonSqueezyConfig(), fetch as any);
+}
+
+function cacheFromResult(result: LicenseValidationResult): CachedEntitlement {
+  return {
+    pro: result.valid,
+    lastValidatedAt: Date.now(),
+    expiresAt: result.expiresAt ? new Date(result.expiresAt).getTime() : undefined,
+  };
+}
+
+/** TierProvider — read at call time so an activation/expiry takes effect immediately. */
+export function getCurrentTier(): Tier {
+  return resolveTier(loadState().cache ?? null);
+}
+
+export function getLicenseStatus(): {
+  tier: Tier;
+  hasLicense: boolean;
+  lastValidatedAt?: number;
+  expiresAt?: number;
+  upgradeUrl: string;
+} {
+  const state = loadState();
+  return {
+    tier: resolveTier(state.cache ?? null),
+    hasLicense: !!state.licenseKey,
+    lastValidatedAt: state.cache?.lastValidatedAt,
+    expiresAt: state.cache?.expiresAt,
+    upgradeUrl: loadLemonSqueezyConfig().checkoutUrl || DEFAULT_UPGRADE_URL,
+  };
+}
+
+export async function activateLicense(licenseKey: string): Promise<LicenseValidationResult> {
+  const result = await service().activate(licenseKey.trim(), `homebot-${os.hostname()}`);
+  if (result.valid) {
+    saveState({ licenseKey: licenseKey.trim(), instanceId: result.instanceId, cache: cacheFromResult(result) });
+  }
+  return result;
+}
+
+export async function validateLicense(): Promise<LicenseValidationResult> {
+  const state = loadState();
+  if (!state.licenseKey) {
+    return { valid: false, error: 'No license activated on this device.' };
+  }
+  const result = await service().validate(state.licenseKey, state.instanceId);
+  saveState({ ...state, cache: cacheFromResult(result) });
+  return result;
+}
+
+export async function deactivateLicense(): Promise<LicenseValidationResult> {
+  const state = loadState();
+  if (!state.licenseKey || !state.instanceId) {
+    saveState({});
+    return { valid: true };
+  }
+  const result = await service().deactivate(state.licenseKey, state.instanceId);
+  saveState({});
+  return result;
+}

--- a/widget/src/preload/index.ts
+++ b/widget/src/preload/index.ts
@@ -529,6 +529,12 @@ const electronAPI: ElectronAPI = {
   schedulerRemove: async (id: string) => ipcRenderer.invoke('homebot:scheduler-remove', id),
   schedulerToggle: async (id: string, enabled: boolean) => ipcRenderer.invoke('homebot:scheduler-toggle', id, enabled),
 
+  // Licensing (Pro entitlement)
+  licenseStatus: async () => ipcRenderer.invoke('homebot:license:status'),
+  licenseActivate: async (licenseKey: string) => ipcRenderer.invoke('homebot:license:activate', licenseKey),
+  licenseValidate: async () => ipcRenderer.invoke('homebot:license:validate'),
+  licenseDeactivate: async () => ipcRenderer.invoke('homebot:license:deactivate'),
+
   // Uncensored mode toggle
   setUncensoredMode: async (enabled: boolean): Promise<{ success: boolean; enabled: boolean }> => {
     return await ipcRenderer.invoke('homebot:set-uncensored-mode', enabled);

--- a/widget/src/renderer/components/ImageGenerator.tsx
+++ b/widget/src/renderer/components/ImageGenerator.tsx
@@ -1,4 +1,7 @@
 import React, { useState, useEffect } from 'react';
+import { isGateBlocked } from '../../shared/upgrade';
+import type { UpgradePrompt } from '../../shared/types';
+import UpgradeModal from './UpgradeModal';
 
 interface SDCppStatus {
   ready: boolean;
@@ -20,6 +23,7 @@ const ImageGenerator: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [sdCppStatus, setSdCppStatus] = useState<SDCppStatus | null>(null);
   const [setupInfo, setSetupInfo] = useState<string[] | null>(null);
+  const [upgradePrompt, setUpgradePrompt] = useState<UpgradePrompt | null>(null);
 
   useEffect(() => {
     (window as any).electron?.sdCppStatus?.().then((s: SDCppStatus) => setSdCppStatus(s));
@@ -46,6 +50,11 @@ const ImageGenerator: React.FC = () => {
 
       if (!result) {
         setError('No response from image generator');
+        return;
+      }
+
+      if (isGateBlocked(result)) {
+        setUpgradePrompt(result.upgrade);
         return;
       }
 
@@ -83,7 +92,7 @@ const ImageGenerator: React.FC = () => {
   return (
     <div className="image-generator">
       <header className="image-header">
-        <h1>Image Generation</h1>
+        <h1>Image Generation <span className="sp-pro-badge" title="Requires HomeBot Pro">⭐ PRO</span></h1>
         <p>Create images with AI</p>
       </header>
 
@@ -195,6 +204,7 @@ const ImageGenerator: React.FC = () => {
           )}
         </div>
       )}
+      <UpgradeModal prompt={upgradePrompt} onClose={() => setUpgradePrompt(null)} />
     </div>
   );
 };

--- a/widget/src/renderer/components/SettingsPanel.tsx
+++ b/widget/src/renderer/components/SettingsPanel.tsx
@@ -5,6 +5,9 @@ import type { Settings as SharedSettings, CustomLLMConfig, CustomModelInfo, Sche
 import { buildSparkline } from '../../shared/sparkline';
 import { buildPerfAdvice } from '../../shared/perf-advice';
 import { buildSupportReport } from '../../shared/support-report';
+import { isGateBlocked } from '../../shared/upgrade';
+import type { LicenseStatus, UpgradePrompt } from '../../shared/types';
+import UpgradeModal from './UpgradeModal';
 
 interface Settings {
   alwaysOnTop: boolean;
@@ -189,6 +192,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
     permissions: true,
     advanced: true,
     diagnostics: false,
+    license: true,
   });
   const toggleSection = (id: string) => setOpenSections(s => ({ ...s, [id]: !s[id] }));
 
@@ -475,6 +479,52 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
     }
   };
 
+  // Pro licensing state
+  const [licenseStatus, setLicenseStatus] = useState<LicenseStatus | null>(null);
+  const [licenseKeyInput, setLicenseKeyInput] = useState('');
+  const [licenseBusy, setLicenseBusy] = useState(false);
+  const [licenseMessage, setLicenseMessage] = useState<string | null>(null);
+  const [upgradePrompt, setUpgradePrompt] = useState<UpgradePrompt | null>(null);
+
+  const loadLicenseStatus = async () => {
+    try {
+      const status = await (window as any).electron?.licenseStatus?.();
+      if (status) setLicenseStatus(status);
+    } catch { /* IPC not yet ready */ }
+  };
+  useEffect(() => { loadLicenseStatus(); }, []);
+
+  const handleActivateLicense = async () => {
+    if (!licenseKeyInput.trim()) return;
+    setLicenseBusy(true);
+    setLicenseMessage(null);
+    try {
+      const result = await (window as any).electron?.licenseActivate?.(licenseKeyInput.trim());
+      if (result?.valid) {
+        setLicenseMessage('✓ Pro activated on this device.');
+        setLicenseKeyInput('');
+      } else {
+        setLicenseMessage(result?.error || 'Activation failed — check the license key.');
+      }
+    } finally {
+      setLicenseBusy(false);
+      loadLicenseStatus();
+    }
+  };
+
+  const handleDeactivateLicense = async () => {
+    if (!confirm('Deactivate Pro on this device? You can reactivate later with the same key.')) return;
+    setLicenseBusy(true);
+    setLicenseMessage(null);
+    try {
+      await (window as any).electron?.licenseDeactivate?.();
+      setLicenseMessage('License deactivated on this device.');
+    } finally {
+      setLicenseBusy(false);
+      loadLicenseStatus();
+    }
+  };
+
   // Scheduler state
   const [scheduledJobs, setScheduledJobs] = useState<ScheduledJob[]>([]);
   const [showJobForm, setShowJobForm] = useState(false);
@@ -490,6 +540,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
     try {
       const jobs = await (window as any).electron?.schedulerList?.();
       if (Array.isArray(jobs)) setScheduledJobs(jobs);
+      else if (isGateBlocked(jobs)) setScheduledJobs([]);
     } catch { /* IPC not yet ready */ }
   };
 
@@ -1718,7 +1769,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
       {/* ── Scheduled Jobs ─────────────────────────────────────────────────── */}
       <div className="settings-section">
         <h3 className="settings-section-title sp-section-title">
-          ⏰ Scheduled Jobs
+          ⏰ Scheduled Jobs <span className="sp-pro-badge" title="Requires HomeBot Pro">⭐ PRO</span>
           <small className="sp-section-subtitle">
             — recurring messages and reminders while HomeBot is open
           </small>
@@ -1821,13 +1872,17 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                   className="button button-save sp-btn-save-sm"
                   onClick={async () => {
                     if (!jobForm.name.trim() || !jobForm.message.trim()) return;
-                    await (window as any).electron?.schedulerAdd?.({
+                    const result = await (window as any).electron?.schedulerAdd?.({
                       name: jobForm.name.trim(),
                       message: jobForm.message.trim(),
                       intervalMinutes: jobForm.intervalMinutes,
                       dailyTime: jobForm.mode === 'daily' ? jobForm.dailyTime : undefined,
                       enabled: true,
                     });
+                    if (isGateBlocked(result)) {
+                      setUpgradePrompt(result.upgrade);
+                      return;
+                    }
                     setJobForm({ name: '', message: '', mode: 'interval', intervalMinutes: 60, dailyTime: '09:00' });
                     setShowJobForm(false);
                     loadJobs();
@@ -2069,6 +2124,70 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
         </div>
       </div>
 
+        {/* HomeBot Pro license */}
+        <button type="button" className={`sp-section-toggle${openSections.license ? ' open' : ''}`} onClick={() => toggleSection('license')}>
+          <span className="sp-section-arrow">{openSections.license ? '▾' : '▸'}</span> HomeBot Pro
+        </button>
+        {openSections.license && <>
+          <div className="setting-group">
+            <label className="setting-label">
+              {licenseStatus?.tier === 'pro' ? '⭐ Pro' : 'Free'}
+              <small className="setting-hint" style={{ display: 'block', marginTop: 2 }}>
+                {licenseStatus?.tier === 'pro'
+                  ? 'Pro unlocks the Automation Center (scheduled jobs) and local image generation.'
+                  : 'Unlock the Automation Center (scheduled jobs) and local image generation with HomeBot Pro.'}
+              </small>
+            </label>
+
+            {licenseStatus?.tier === 'pro' ? (
+              <>
+                {licenseStatus.expiresAt && (
+                  <small className="setting-hint" style={{ display: 'block', marginBottom: 8 }}>
+                    Renews/expires {new Date(licenseStatus.expiresAt).toLocaleDateString()}
+                  </small>
+                )}
+                <button
+                  type="button"
+                  className="button button-cancel"
+                  disabled={licenseBusy}
+                  onClick={() => { void handleDeactivateLicense(); }}
+                >
+                  Deactivate on this device
+                </button>
+              </>
+            ) : (
+              <div className="sp-form-col">
+                <input
+                  className="setting-input"
+                  placeholder="Enter your license key"
+                  value={licenseKeyInput}
+                  onChange={(e) => setLicenseKeyInput(e.target.value)}
+                  disabled={licenseBusy}
+                />
+                <div className="sp-mcp-actions">
+                  <button
+                    type="button"
+                    className="button sp-license-activate-btn sp-btn-save-sm"
+                    disabled={licenseBusy || !licenseKeyInput.trim()}
+                    onClick={() => { void handleActivateLicense(); }}
+                  >
+                    {licenseBusy ? 'Activating…' : 'Activate'}
+                  </button>
+                  <button
+                    type="button"
+                    className="button button-cancel sp-btn-save-sm"
+                    onClick={() => window.electron?.openExternalUrl?.(licenseStatus?.upgradeUrl || 'sadie://upgrade')}
+                  >
+                    Get a license
+                  </button>
+                </div>
+              </div>
+            )}
+            {licenseMessage && (
+              <small className="setting-hint" style={{ display: 'block', marginTop: 8 }}>{licenseMessage}</small>
+            )}
+          </div>
+        </>}
 
         {/* Diagnostics & Performance */}
         <button type="button" className={`sp-section-toggle${openSections.diagnostics ? ' open' : ''}`} onClick={() => toggleSection('diagnostics')}>
@@ -2210,6 +2329,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
         </button>
       </div>
       </div>
+      <UpgradeModal prompt={upgradePrompt} onClose={() => setUpgradePrompt(null)} />
     </div>
   );
 };

--- a/widget/src/renderer/components/UpgradeModal.tsx
+++ b/widget/src/renderer/components/UpgradeModal.tsx
@@ -1,0 +1,42 @@
+import type { UpgradePrompt } from '../../shared/types';
+
+/**
+ * Shown whenever a Pro-gated IPC call resolves to a GateBlockedResponse.
+ * Reuses the existing `hb-modal-*` styling used by SettingsModal.
+ */
+export function UpgradeModal({
+  prompt,
+  onClose,
+}: {
+  prompt: UpgradePrompt | null;
+  onClose: () => void;
+}) {
+  if (!prompt) return null;
+
+  return (
+    <div className="hb-modal-overlay">
+      <div className="hb-modal-card hb-modal-card-sm">
+        <h2 className="hb-modal-title">⭐ {prompt.title || 'Upgrade to Pro'}</h2>
+        <p style={{ opacity: 0.85, lineHeight: 1.5, margin: '4px 0 16px' }}>
+          {prompt.message || 'This feature requires HomeBot Pro.'}
+        </p>
+        <div className="hb-modal-actions">
+          <button className="hb-modal-btn hb-modal-btn-secondary" onClick={onClose}>
+            Not now
+          </button>
+          <button
+            className="hb-modal-btn hb-modal-btn-primary"
+            onClick={() => {
+              window.electron?.openExternalUrl?.(prompt.upgradeUrl);
+              onClose();
+            }}
+          >
+            Upgrade to Pro
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default UpgradeModal;

--- a/widget/src/renderer/styles/chatgpt-theme.css
+++ b/widget/src/renderer/styles/chatgpt-theme.css
@@ -2372,6 +2372,7 @@ body {
 
 .sp-section-title { display: flex; align-items: center; gap: 8px; }
 .sp-section-subtitle { font-weight: 400; font-size: 0.75em; color: var(--text-muted); }
+.sp-pro-badge { font-size: 0.7em; font-weight: 700; color: #1a1a1a; background: linear-gradient(135deg, #ffd966, #ffb84d); border-radius: 999px; padding: 2px 8px; letter-spacing: 0.02em; }
 .sp-empty-hint { font-size: 0.85em; color: var(--text-muted); margin: 4px 0 12px; }
 .sp-list { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
 .sp-list-row { display: flex; align-items: center; justify-content: space-between; background: var(--bg-medium); border-radius: 6px; padding: 6px 10px; font-size: 0.85em; }

--- a/widget/src/shared/types.ts
+++ b/widget/src/shared/types.ts
@@ -1,3 +1,40 @@
+// ── Pro licensing / entitlements (renderer-facing mirror of src/entitlements + src/licensing) ──
+export type LicenseTier = 'free' | 'pro';
+
+export interface UpgradePrompt {
+  reason: 'upgrade_required';
+  capability: string;
+  requiredTier: LicenseTier;
+  title: string;
+  message: string;
+  upgradeUrl: string;
+}
+
+/** Shape returned by a Pro-gated IPC handler when the caller is on Free. */
+export interface GateBlockedResponse {
+  status: 'upgrade_required';
+  upgrade: UpgradePrompt;
+}
+
+export interface LicenseStatus {
+  tier: LicenseTier;
+  hasLicense: boolean;
+  lastValidatedAt?: number;
+  expiresAt?: number;
+  upgradeUrl: string;
+}
+
+/** Result of an activate/validate/deactivate call against the license provider. */
+export interface LicenseActionResult {
+  valid: boolean;
+  status?: string;
+  instanceId?: string;
+  activationUsage?: number;
+  activationLimit?: number;
+  expiresAt?: string | null;
+  error?: string;
+}
+
 export interface HomeBotRequest {
   user_id: string;
   conversation_id: string;
@@ -269,12 +306,18 @@ export interface ElectronAPI {
   ttsSpeak?: (text: string, rate?: number) => Promise<{ success: boolean; error?: string }>;
   ttsStop?: () => Promise<{ success: boolean; error?: string }>;
 
-  // Scheduler
-  schedulerList?: () => Promise<ScheduledJob[]>;
-  schedulerAdd?: (input: Omit<ScheduledJob, 'id' | 'createdAt'>) => Promise<{ success: boolean; job?: ScheduledJob; error?: string }>;
-  schedulerRemove?: (id: string) => Promise<{ success: boolean }>;
-  schedulerToggle?: (id: string, enabled: boolean) => Promise<{ success: boolean; job?: ScheduledJob; error?: string }>;
-  
+  // Scheduler (Pro-gated — handlers may resolve to GateBlockedResponse for free users)
+  schedulerList?: () => Promise<ScheduledJob[] | GateBlockedResponse>;
+  schedulerAdd?: (input: Omit<ScheduledJob, 'id' | 'createdAt'>) => Promise<{ success: boolean; job?: ScheduledJob; error?: string } | GateBlockedResponse>;
+  schedulerRemove?: (id: string) => Promise<{ success: boolean } | GateBlockedResponse>;
+  schedulerToggle?: (id: string, enabled: boolean) => Promise<{ success: boolean; job?: ScheduledJob; error?: string } | GateBlockedResponse>;
+
+  // Licensing (Pro entitlement — Lemon Squeezy backed)
+  licenseStatus?: () => Promise<LicenseStatus>;
+  licenseActivate?: (licenseKey: string) => Promise<LicenseActionResult>;
+  licenseValidate?: () => Promise<LicenseActionResult>;
+  licenseDeactivate?: () => Promise<LicenseActionResult>;
+
   // Uncensored mode toggle
   setUncensoredMode?: (enabled: boolean) => Promise<{ success: boolean; enabled: boolean }>;
   getUncensoredMode?: () => Promise<{ enabled: boolean }>;

--- a/widget/src/shared/upgrade.ts
+++ b/widget/src/shared/upgrade.ts
@@ -1,0 +1,6 @@
+import type { GateBlockedResponse } from './types';
+
+/** True when a Pro-gated IPC call resolved to an upgrade_required response. */
+export function isGateBlocked(value: unknown): value is GateBlockedResponse {
+  return !!value && typeof value === 'object' && (value as any).status === 'upgrade_required';
+}


### PR DESCRIPTION
## Summary
- Wires Step 1's licensing/entitlements scaffolding (`src/licensing`, `src/entitlements`, `src/handlers/featureGate.ts`, `src/handlers/automationCenter.ts`) into the real Electron app, per the Free-vs-Pro spec's P2 requirement ("Pro badges on locked features, upgrade modal, license-key entry screen, deep link to LS checkout").
- New `widget/src/main/licensing.ts`: persists a `CachedEntitlement` + activated license to `userData/license.json`, exposes `getCurrentTier()` as the `TierProvider` for the handler-layer gate, and wraps Lemon Squeezy activate/validate/deactivate.
- Gated the Automation Center IPC channels (`homebot:automation:image:generate`, `homebot:scheduler-list/-add/-remove/-toggle`) with `withFeatureGate`/`gatedAutomationHandler`. Also fixed `automationCenter.ts`'s channel map, which listed placeholder channel names (`homebot:automation:scheduler:add`, etc.) that don't exist anywhere in the app — the gate was wired but unreachable until this fix aligned it to the literal channel strings registered in `ipc-handlers.ts`.
- New `homebot:license:{status,activate,validate,deactivate}` IPC channels, exposed via preload + shared `ElectronAPI` types (`LicenseStatus`, `LicenseActionResult`, `UpgradePrompt`, `GateBlockedResponse`).
- Renderer: a License section in Settings (key entry, activate/deactivate, status), a reusable `UpgradeModal`, and Pro badges on Scheduled Jobs / Image Generation. Both `SettingsPanel` and `ImageGenerator` now detect a `GateBlockedResponse` from gated IPC calls and show the upgrade modal instead of a generic error.
- Fixed a `.button-save` class collision: the License section's "Activate" button reused that class, which broke 3 existing `SettingsPanel` tests (`settings-cloud-default`, `message-density`, `notification-preferences`) that select the footer Save button via `container.querySelector('.button-save')`.

## Test plan
- [x] `npx jest src/__tests__/{gating,licensing,entitlements}.test.ts` — 35/35 pass
- [x] `widget: npx jest --config=jest.config.ts --testPathPattern=licensing.test.ts` — 6/6 pass (new)
- [x] `widget: npx jest --config=jest.config.ts --testPathPattern="settings-cloud-default|message-density|notification-preferences"` — 9/9 pass (regression fixed)
- [x] `widget: npx jest --config=jest.config.ts --testPathIgnorePatterns=e2e` — 1662/1775 pass; remaining failures confirmed pre-existing on `main` (Electron binary not installed in this sandbox, or unrelated stale assertions) via a `git stash` A/B comparison
- [x] `widget: npx tsc --noEmit -p tsconfig.json` — clean
- [x] `widget: npm run build` (electron-vite) — clean, all three targets (main/preload/renderer) build
- [x] `widget: npx eslint` on all changed files — clean (one pre-existing unrelated warning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pv9HH9D1X6prBxxV3euwzv)_