### PR TITLE
Reflection validation layer for tool outputs (rework of #11)

### DIFF
--- a/widget/src/main/__tests__/reflection-validator.test.ts
+++ b/widget/src/main/__tests__/reflection-validator.test.ts
@@ -1,0 +1,188 @@
+import axios from 'axios';
+import {
+  evaluateToolResults,
+  parseReflectionVerdict,
+  REFLECTION_CONFIDENCE_THRESHOLD,
+  MAX_REFLECTION_DEPTH
+} from '../reflection-validator';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('constants', () => {
+  it('exposes the expected confidence threshold and depth budget', () => {
+    expect(REFLECTION_CONFIDENCE_THRESHOLD).toBe(0.7);
+    expect(MAX_REFLECTION_DEPTH).toBe(2);
+  });
+});
+
+describe('parseReflectionVerdict', () => {
+  it('parses a valid accept verdict', () => {
+    const v = parseReflectionVerdict(JSON.stringify({
+      outcome: 'accept',
+      confidence: 0.92,
+      final_message: 'The answer is 42.'
+    }));
+    expect(v).toEqual({ outcome: 'accept', confidence: 0.92, final_message: 'The answer is 42.' });
+  });
+
+  it('parses a valid request_tool verdict', () => {
+    const v = parseReflectionVerdict(JSON.stringify({
+      outcome: 'request_tool',
+      confidence: 0.4,
+      tool_request: { name: 'web_search', arguments: { query: 'more info' } }
+    }));
+    expect(v).toEqual({
+      outcome: 'request_tool',
+      confidence: 0.4,
+      tool_request: { name: 'web_search', arguments: { query: 'more info' } }
+    });
+  });
+
+  it('parses a valid explain verdict', () => {
+    const v = parseReflectionVerdict(JSON.stringify({
+      outcome: 'explain',
+      confidence: null,
+      explanation: "couldn't validate the tool output"
+    }));
+    expect(v).toEqual({ outcome: 'explain', confidence: null, explanation: "couldn't validate the tool output" });
+  });
+
+  it('rejects non-JSON', () => {
+    expect(parseReflectionVerdict('not json at all')).toBeNull();
+  });
+
+  it('rejects JSON with markdown fences', () => {
+    expect(parseReflectionVerdict('```json\n{"outcome":"accept","confidence":0.9,"final_message":"hi"}\n```')).toBeNull();
+  });
+
+  it('rejects an unknown outcome', () => {
+    expect(parseReflectionVerdict(JSON.stringify({ outcome: 'maybe', confidence: 0.5 }))).toBeNull();
+  });
+
+  it('rejects accept without final_message', () => {
+    expect(parseReflectionVerdict(JSON.stringify({ outcome: 'accept', confidence: 0.9 }))).toBeNull();
+  });
+
+  it('rejects request_tool without a tool name', () => {
+    expect(parseReflectionVerdict(JSON.stringify({ outcome: 'request_tool', tool_request: {} }))).toBeNull();
+  });
+
+  it('rejects explain without an explanation', () => {
+    expect(parseReflectionVerdict(JSON.stringify({ outcome: 'explain' }))).toBeNull();
+  });
+
+  it('rejects arrays and non-objects', () => {
+    expect(parseReflectionVerdict('[1,2,3]')).toBeNull();
+    expect(parseReflectionVerdict('"just a string"')).toBeNull();
+  });
+
+  it('rejects empty input', () => {
+    expect(parseReflectionVerdict('')).toBeNull();
+    // @ts-expect-error intentional bad input
+    expect(parseReflectionVerdict(undefined)).toBeNull();
+  });
+});
+
+describe('evaluateToolResults', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const baseArgs = {
+    ollamaBaseUrl: 'http://127.0.0.1:11434',
+    model: 'qwen2.5:7b',
+    userMessage: 'what is the weather in Tauranga',
+    toolSummary: '{"temperature":18,"condition":"cloudy"}',
+    depth: 0
+  };
+
+  it('accepts high-confidence verdicts', async () => {
+    const res = await evaluateToolResults({
+      ...baseArgs,
+      __testOverride: { outcome: 'accept', confidence: 0.92, final_message: "It's 18°C and cloudy in Tauranga." }
+    });
+    expect(res.accepted).toBe(true);
+    expect(res.confidence).toBe(0.92);
+    expect(res.message).toBe("It's 18°C and cloudy in Tauranga.");
+    expect(res.fallback).toBe(false);
+  });
+
+  it('flags low-confidence accepts as unaccepted with a caution note', async () => {
+    const res = await evaluateToolResults({
+      ...baseArgs,
+      __testOverride: { outcome: 'accept', confidence: 0.4, final_message: 'Probably 18°C.' }
+    });
+    expect(res.accepted).toBe(false);
+    expect(res.message).toMatch(/low confidence/i);
+  });
+
+  it('treats accept with null confidence as below threshold', async () => {
+    const res = await evaluateToolResults({
+      ...baseArgs,
+      __testOverride: { outcome: 'accept', confidence: null, final_message: 'Hard to say.' }
+    });
+    expect(res.accepted).toBe(false);
+  });
+
+  it('surfaces a tool_request so the caller can run another round', async () => {
+    const res = await evaluateToolResults({
+      ...baseArgs,
+      __testOverride: {
+        outcome: 'request_tool',
+        confidence: 0.3,
+        tool_request: { name: 'web_search', arguments: { query: 'Tauranga weather today' } }
+      }
+    });
+    expect(res.accepted).toBe(false);
+    expect(res.toolRequest).toEqual({ name: 'web_search', arguments: { query: 'Tauranga weather today' } });
+    expect(res.fallback).toBe(false);
+  });
+
+  it('surfaces an explanation on explain outcome', async () => {
+    const res = await evaluateToolResults({
+      ...baseArgs,
+      __testOverride: { outcome: 'explain', confidence: null, explanation: "couldn't validate the tool output" }
+    });
+    expect(res.accepted).toBe(false);
+    expect(res.message).toMatch(/couldn't validate the tool output/i);
+    expect(res.fallback).toBe(false);
+  });
+
+  it('force-accepts once the reflection depth budget is exhausted', async () => {
+    const res = await evaluateToolResults({ ...baseArgs, depth: MAX_REFLECTION_DEPTH });
+    expect(res.accepted).toBe(true);
+    expect(res.fallback).toBe(true);
+    expect(res.message).toMatch(/depth limit/i);
+  });
+
+  it('falls back to accept when the model returns invalid JSON', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { response: 'not valid json' } });
+    const res = await evaluateToolResults(baseArgs);
+    expect(res.accepted).toBe(true);
+    expect(res.fallback).toBe(true);
+  });
+
+  it('falls back to accept when the request errors out (network down, etc.)', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const res = await evaluateToolResults(baseArgs);
+    expect(res.accepted).toBe(true);
+    expect(res.fallback).toBe(true);
+  });
+
+  it('calls Ollama /api/generate with a strict-JSON request when no override is given', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { response: JSON.stringify({ outcome: 'accept', confidence: 0.8, final_message: 'ok' }) }
+    });
+    await evaluateToolResults(baseArgs);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'http://127.0.0.1:11434/api/generate',
+      expect.objectContaining({ model: 'qwen2.5:7b', format: 'json', stream: false })
+    );
+  });
+
+  it('never throws even on unexpected axios rejection shapes', async () => {
+    mockedAxios.post.mockRejectedValueOnce('a raw string rejection, not an Error');
+    await expect(evaluateToolResults(baseArgs)).resolves.toMatchObject({ accepted: true, fallback: true });
+  });
+});

--- a/widget/src/main/config-manager.ts
+++ b/widget/src/main/config-manager.ts
@@ -108,6 +108,10 @@ export interface Settings {
   projectPath?: string;
   // Default location for weather queries when user doesn't specify one
   defaultLocation?: string;
+  // Reflection validation: after a tool batch runs, ask the model to verify
+  // the result actually answers the request before surfacing it. Off by
+  // default — additive safety layer, opt-in while it proves itself out.
+  reflectionValidationEnabled?: boolean;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -115,6 +119,7 @@ const DEFAULT_SETTINGS: Settings = {
   // Prefer IPv4 to avoid ::1 resolution issues on Windows
   ollamaUrl: 'http://127.0.0.1:11434',
   modelRoutingMode: 'prompt',
+  reflectionValidationEnabled: false,
   chatModel: 'qwen2.5:7b',               // best IQ + tool-calling at 7B
   uncensoredModel: 'dolphin:7b',
   visionModel: 'moondream',            // 1.7 GB — replaces llava (4.7 GB)

--- a/widget/src/main/message-router.ts
+++ b/widget/src/main/message-router.ts
@@ -9,6 +9,7 @@ import { HomeBotRequest, HomeBotResponse, HomeBotRequestWithImages, ImageAttachm
 import { IPC_SEND_MESSAGE, HOMEBOT_WEBHOOK_PATH, DEFAULT_OLLAMA_URL } from '../shared/constants';
 import { HOMEBOT_SYSTEM_PROMPT, HOMEBOT_SYSTEM_PROMPT_COMPACT } from '../shared/system-prompt';
 import { initializeTools, getFocusedOllamaTools, getFocusedToolDefinitions, getSmallModelTools, executeToolBatch, ToolCall, ToolContext } from './tools';
+import { evaluateToolResults } from './reflection-validator';
 import { documentToolHandlers } from './tools/documents';
 import { isE2E, isPackagedBuild } from './env';
 import { getSettings, saveSettings } from './config-manager';
@@ -3126,6 +3127,43 @@ export async function streamFromOllamaWithTools(
             if (r.precipitation) toolContent += `\nPrecipitation: ${r.precipitation}`;
           }
           messages.push({ role: 'tool', content: toolContent });
+        }
+
+        // Optional reflection validation: ask the model to verify the tool
+        // results actually answer the request before continuing. Disabled by
+        // default; any failure inside this layer falls back to existing
+        // behavior (continue to next round) so it can never block the chat.
+        if (getSettings().reflectionValidationEnabled) {
+          try {
+            const toolSummary = batchResults.map(r => JSON.stringify(r)).join('\n');
+            const reflection = await evaluateToolResults({
+              ollamaBaseUrl: ollamaBase,
+              model,
+              userMessage: message,
+              toolSummary,
+              depth: round
+            });
+            if (!reflection.fallback) {
+              if (reflection.accepted) {
+                onChunk(reflection.message);
+                safeEnd('reflection-accepted');
+                return;
+              }
+              if (reflection.toolRequest) {
+                messages.push({
+                  role: 'system',
+                  content: `Reflection requested another tool call: ${reflection.toolRequest.name}. Continue accordingly.`
+                });
+              } else if (reflection.message) {
+                onChunk(reflection.message);
+                safeEnd('reflection-explained');
+                return;
+              }
+            }
+          } catch (e) {
+            safeCatch(e);
+            // fall through to default behavior below
+          }
         }
 
         // Continue the conversation with tool results

--- a/widget/src/main/reflection-validator.ts
+++ b/widget/src/main/reflection-validator.ts
@@ -1,0 +1,181 @@
+/**
+ * Reflection Validator
+ * ---------------------
+ * A model-first validation layer for tool-call output. After a batch of tools
+ * has executed, this asks the LLM to render a verdict on whether the results
+ * actually answer the user's request, using a strict single-JSON-object
+ * response shape. This lets HomeBot catch cases where a tool technically
+ * "succeeded" but the result doesn't actually satisfy what was asked (wrong
+ * location matched, stale data, partial result, etc.) before handing the
+ * answer to the user.
+ *
+ * Design goals:
+ * - Fully additive: disabled by default (Settings.reflectionValidationEnabled).
+ * - Fail-safe: any parsing/network error falls back to "accept" so a bug in
+ *   this module can never block or corrupt the existing conversation flow.
+ * - Depth-limited: independent of MAX_TOOL_ROUNDS, reflection itself can only
+ *   escalate a bounded number of times before it force-accepts.
+ */
+
+import axios from 'axios';
+
+export const REFLECTION_CONFIDENCE_THRESHOLD = 0.7;
+export const MAX_REFLECTION_DEPTH = 2;
+
+export type ReflectionOutcome = 'accept' | 'request_tool' | 'explain';
+
+export interface ReflectionVerdict {
+  outcome: ReflectionOutcome;
+  confidence: number | null;
+  final_message?: string;
+  tool_request?: { name: string; arguments?: Record<string, unknown> };
+  explanation?: string;
+}
+
+export interface ReflectionResult {
+  /** Whether the verdict should be treated as accepted (surfaced to the user as-is). */
+  accepted: boolean;
+  confidence: number | null;
+  /** Message to show the user, whichever path was taken. */
+  message: string;
+  /** Present only when outcome === 'request_tool' and depth budget remains. */
+  toolRequest?: { name: string; arguments?: Record<string, unknown> };
+  /** True when reflection itself failed (bad JSON, network error, etc.) — caller should treat as accept and move on unchanged. */
+  fallback: boolean;
+}
+
+interface EvaluateArgs {
+  ollamaBaseUrl: string;
+  model: string;
+  userMessage: string;
+  toolSummary: string;
+  depth: number;
+  /** Injection point for tests to control the exact response without mocking axios internals. */
+  __testOverride?: ReflectionVerdict;
+}
+
+function buildReflectionPrompt(userMessage: string, toolSummary: string): string {
+  return [
+    'You are validating whether tool output actually answers a user request.',
+    'Respond with EXACTLY ONE JSON object and nothing else — no prose, no markdown fences.',
+    'Shape: {"outcome":"accept"|"request_tool"|"explain","confidence":0-1 or null,',
+    '"final_message"?:string, "tool_request"?:{"name":string,"arguments"?:object}, "explanation"?:string}',
+    '- "accept": the tool output answers the request. Include final_message (what to tell the user) and confidence.',
+    '- "request_tool": the output is insufficient and another tool call would help. Include tool_request.',
+    '- "explain": the output cannot be validated or is wrong. Include explanation (plain language, no confidence needed).',
+    '',
+    `User request: ${userMessage}`,
+    '',
+    `Tool output: ${toolSummary}`
+  ].join('\n');
+}
+
+/** Strictly parses a model response as a single ReflectionVerdict JSON object. Returns null on any deviation. */
+export function parseReflectionVerdict(raw: string): ReflectionVerdict | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  let parsed: any;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const outcome = parsed.outcome;
+  if (outcome !== 'accept' && outcome !== 'request_tool' && outcome !== 'explain') return null;
+
+  const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : null;
+
+  if (outcome === 'request_tool') {
+    const tr = parsed.tool_request;
+    if (!tr || typeof tr !== 'object' || typeof tr.name !== 'string' || !tr.name) return null;
+    return { outcome, confidence, tool_request: { name: tr.name, arguments: tr.arguments } };
+  }
+  if (outcome === 'explain') {
+    if (typeof parsed.explanation !== 'string' || !parsed.explanation.trim()) return null;
+    return { outcome, confidence, explanation: parsed.explanation };
+  }
+  // accept
+  if (typeof parsed.final_message !== 'string' || !parsed.final_message.trim()) return null;
+  return { outcome, confidence, final_message: parsed.final_message };
+}
+
+/**
+ * Ask the model to validate tool output and return a normalized result the
+ * caller can act on. Never throws — any failure degrades to an accepted
+ * fallback so the existing conversation flow is never blocked by this layer.
+ */
+export async function evaluateToolResults(args: EvaluateArgs): Promise<ReflectionResult> {
+  const { ollamaBaseUrl, model, userMessage, toolSummary, depth } = args;
+
+  if (depth >= MAX_REFLECTION_DEPTH) {
+    return {
+      accepted: true,
+      confidence: null,
+      message: 'Reached the reflection depth limit — showing the best available result.',
+      fallback: true
+    };
+  }
+
+  let verdict: ReflectionVerdict | null;
+
+  if (args.__testOverride) {
+    verdict = args.__testOverride;
+  } else {
+    try {
+      const prompt = buildReflectionPrompt(userMessage, toolSummary);
+      const response = await axios.post(`${ollamaBaseUrl}/api/generate`, {
+        model,
+        prompt,
+        stream: false,
+        format: 'json',
+        options: { temperature: 0, num_predict: 512 }
+      });
+      const raw = response?.data?.response ?? '';
+      verdict = parseReflectionVerdict(raw);
+    } catch {
+      verdict = null;
+    }
+  }
+
+  if (!verdict) {
+    return {
+      accepted: true,
+      confidence: null,
+      message: 'Reflection could not validate the tool output — showing it as-is.',
+      fallback: true
+    };
+  }
+
+  if (verdict.outcome === 'accept') {
+    const confidence = verdict.confidence ?? 0;
+    const accepted = confidence >= REFLECTION_CONFIDENCE_THRESHOLD;
+    return {
+      accepted,
+      confidence: verdict.confidence,
+      message: accepted
+        ? (verdict.final_message as string)
+        : `${verdict.final_message} (low confidence — treat with caution)`,
+      fallback: false
+    };
+  }
+
+  if (verdict.outcome === 'request_tool') {
+    return {
+      accepted: false,
+      confidence: verdict.confidence,
+      message: '',
+      toolRequest: verdict.tool_request,
+      fallback: false
+    };
+  }
+
+  // explain
+  return {
+    accepted: false,
+    confidence: verdict.confidence,
+    message: verdict.explanation as string,
+    fallback: false
+  };
+}


### PR DESCRIPTION
Reworks the reflection-loop concept from stale PR #11 against current main. #11 targeted an old n8n request/response architecture that no longer exists (374 commits drift, every commit conflicted on cherry-pick) — this is a clean reimplementation against the live `streamFromOllamaWithTools` / `ToolRegistry` architecture instead.

- New self-contained `reflection-validator.ts` module, fully unit tested (22 tests, all passing)
- Fail-safe: any error in this layer falls back to existing behavior untouched
- Off by default via `Settings.reflectionValidationEnabled` — opt-in
- Full suite run: zero regressions vs main (same pre-existing sandbox-only electron-binary failures)

Supersedes #11 and #12.