### PR TITLE
a11y: accessible PermissionModal dialog (#6)

### DIFF
--- a/widget/src/renderer/__tests__/permission-modal.test.tsx
+++ b/widget/src/renderer/__tests__/permission-modal.test.tsx
@@ -137,3 +137,52 @@ test('Always allow still sends response even if getSettings throws', async () =>
   expect(el.sendPermissionResponse).toHaveBeenCalledWith('req-123', 'always_allow', PERMS);
   expect(onClose).toHaveBeenCalled();
 });
+
+// ─── accessibility (issue #6) ─────────────────────────────────────────────────
+
+test('exposes a labelled, described modal dialog', () => {
+  setup();
+  const dialog = screen.getByRole('dialog');
+  expect(dialog).toHaveAttribute('aria-modal', 'true');
+  // accessible name comes from the heading
+  expect(dialog).toHaveAccessibleName('Permission Required');
+  // described by the intro + reason text
+  const describedby = dialog.getAttribute('aria-describedby') || '';
+  expect(describedby.split(' ').length).toBe(2);
+});
+
+test('permissions are exposed as a semantic list', () => {
+  setup();
+  expect(screen.getByRole('list', { name: /requested permissions/i })).toBeInTheDocument();
+  expect(screen.getAllByRole('listitem')).toHaveLength(PERMS.length);
+});
+
+test('focus moves to the Cancel button when opened', () => {
+  setup();
+  expect(screen.getByRole('button', { name: /cancel/i })).toHaveFocus();
+});
+
+test('Escape key declines the request (cancel) and closes', () => {
+  const { el, onClose } = setup();
+  fireEvent.keyDown(document, { key: 'Escape' });
+  expect(el.sendPermissionResponse).toHaveBeenCalledWith('req-123', 'cancel');
+  expect(onClose).toHaveBeenCalled();
+});
+
+test('does not handle Escape when closed', () => {
+  const { el } = setup({ open: false });
+  fireEvent.keyDown(document, { key: 'Escape' });
+  expect(el.sendPermissionResponse).not.toHaveBeenCalled();
+});
+
+test('clarifies the difference between Allow once and Always allow', () => {
+  setup();
+  expect(screen.getByText(/saves these permissions for future actions/i)).toBeInTheDocument();
+});
+
+test('action buttons are type="button" (no accidental form submit)', () => {
+  setup();
+  for (const name of [/cancel/i, /allow once/i, /always allow/i]) {
+    expect(screen.getByRole('button', { name })).toHaveAttribute('type', 'button');
+  }
+});

--- a/widget/src/renderer/components/PermissionModal.tsx
+++ b/widget/src/renderer/components/PermissionModal.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useRef } from 'react';
 
+const TITLE_ID = 'hb-permission-modal-title';
+const INTRO_ID = 'hb-permission-modal-intro';
+const REASON_ID = 'hb-permission-modal-reason';
 
 export default function PermissionModal({ open, missingPermissions, reason, requestId, onClose }: {
   open: boolean;
@@ -7,7 +11,62 @@ export default function PermissionModal({ open, missingPermissions, reason, requ
   requestId?: string;
   onClose: () => void;
 }) {
-  if (!open || !requestId) return null;
+  const active = open && !!requestId;
+
+  const cardRef = useRef<HTMLDivElement>(null);
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  // Accessibility: focus management, focus trap, and Escape-to-cancel.
+  // Hooks must run unconditionally (rules-of-hooks) — the effect no-ops when
+  // the modal is not active, so nothing happens until it is actually shown.
+  useEffect(() => {
+    if (!active) return;
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    // Focus the safest default action (Cancel) so keyboard users start on the
+    // least-destructive choice rather than "Always allow".
+    cancelBtnRef.current?.focus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        // Escape is treated as an explicit decline — same as Cancel.
+        e.preventDefault();
+        (window as any).electron.sendPermissionResponse(requestId!, 'cancel');
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab') {
+        const card = cardRef.current;
+        if (!card) return;
+        const focusables = Array.from(
+          card.querySelectorAll<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+          ),
+        ).filter((el) => !el.hasAttribute('disabled'));
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      // Restore focus to whatever was focused before the modal opened.
+      const prev = previouslyFocused.current;
+      if (prev && typeof prev.focus === 'function') prev.focus();
+    };
+  }, [active, requestId, onClose]);
+
+  if (!active) return null;
 
   const allowOnce = () => {
     (window as any).electron.sendPermissionResponse(requestId!, 'allow_once', missingPermissions);
@@ -32,20 +91,30 @@ export default function PermissionModal({ open, missingPermissions, reason, requ
 
   return (
     <div data-role="permission-modal" className="hb-modal-overlay">
-      <div className="hb-modal-card hb-modal-card-lg">
-        <h2 className="hb-modal-title">Permission Required</h2>
-        <p className="hb-modal-text">This action requires the following permissions:</p>
-        <div className="hb-modal-consent-detail">
+      <div
+        ref={cardRef}
+        className="hb-modal-card hb-modal-card-lg"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={TITLE_ID}
+        aria-describedby={`${INTRO_ID} ${REASON_ID}`}
+      >
+        <h2 id={TITLE_ID} className="hb-modal-title">Permission Required</h2>
+        <p id={INTRO_ID} className="hb-modal-text">This action requires the following permissions:</p>
+        <div className="hb-modal-consent-detail" role="list" aria-label="Requested permissions">
           {missingPermissions.map((p) => (
-            <div key={p} className="hb-modal-perm-item">{p.replace(/_/g, ' ')}</div>
+            <div key={p} className="hb-modal-perm-item" role="listitem">{p.replace(/_/g, ' ')}</div>
           ))}
         </div>
-        <div className="hb-modal-muted">{reason || 'This action will modify files on your system.'}</div>
+        <div id={REASON_ID} className="hb-modal-muted">{reason || 'This action will modify files on your system.'}</div>
+        <p className="hb-modal-muted hb-modal-perm-hint">
+          <strong>Allow once</strong> applies only to this action. <strong>Always allow</strong> saves these permissions for future actions until you change them in Settings.
+        </p>
 
         <div className="hb-modal-actions">
-          <button className="hb-modal-btn hb-modal-btn-secondary" onClick={cancel}>Cancel</button>
-          <button className="hb-modal-btn hb-modal-btn-warning" onClick={allowOnce}>Allow once</button>
-          <button className="hb-modal-btn hb-modal-btn-primary" onClick={alwaysAllow}>Always allow</button>
+          <button ref={cancelBtnRef} type="button" className="hb-modal-btn hb-modal-btn-secondary" onClick={cancel}>Cancel</button>
+          <button type="button" className="hb-modal-btn hb-modal-btn-warning" onClick={allowOnce}>Allow once</button>
+          <button type="button" className="hb-modal-btn hb-modal-btn-primary" onClick={alwaysAllow}>Always allow</button>
         </div>
       </div>
     </div>

--- a/widget/src/renderer/styles/chatgpt-theme.css
+++ b/widget/src/renderer/styles/chatgpt-theme.css
@@ -3421,6 +3421,11 @@ body {
 }
 .hb-modal-consent-detail > * + * { margin-top: var(--spacing-sm); }
 .hb-modal-consent-version { color: var(--text-secondary); }
+.hb-modal-perm-hint {
+  font-size: var(--font-size-sm);
+  margin-top: calc(-1 * var(--spacing-xs));
+}
+.hb-modal-perm-hint strong { color: var(--text-primary); font-weight: 600; }
 
 /* ═══════════════════════════════════════════════════════════════════
    TelemetryDashboard (Analytics Panel)


### PR DESCRIPTION
## What
Implements the **"Improve permission modal copy and accessibility"** item from issue #6.

The permission consent dialog is a security-critical surface but was not accessible: no dialog semantics, no focus management, no keyboard dismissal, and the permission list was anonymous divs.

## Accessibility
- role="dialog" + aria-modal="true", aria-labelledby (title) and aria-describedby (intro + reason)
- Requested permissions now a semantic role="list" / role="listitem" with an accessible name
- Focus moves to **Cancel** (least-destructive) on open; **Tab focus-trap** keeps focus in the dialog; focus is **restored** on close
- **Escape** now declines (same as Cancel) — was previously missing
- Buttons are type="button"

## Copy
- Added a one-line hint distinguishing **Allow once** (this action only) from **Always allow** (persists until changed in Settings) — clearer informed consent

## Safety
- No change to the permission decision flow or the sendPermissionResponse / settings IPC contract
- Hooks moved above the early return (rules-of-hooks)
- All 16 existing tests preserved; **7 new tests** added (dialog semantics, list roles, initial focus, Escape-to-decline, button type)
- Lint clean (0 errors), permission-modal suite **23/23 green**, permissions-smoke green

Refs #6
