### PR TITLE
feat(crm): crm_export — full data portability (CSV per table + combined JSON)

### DIFF
--- a/src/__tests__/crm-store.test.ts
+++ b/src/__tests__/crm-store.test.ts
@@ -324,3 +324,71 @@ describe('CrmStore — audit log', () => {
     store.close();
   });
 });
+
+describe('CrmStore — exportAll', () => {
+  const fs = require('fs') as typeof import('fs');
+  const os = require('os') as typeof import('os');
+  const path = require('path') as typeof import('path');
+
+  test('writes one CSV per table plus combined JSON, with correct counts', () => {
+    const store = freshStore();
+    const company = store.createCompany({ name: 'Comma, Quote "Co"', domain: 'cq.co.nz' });
+    const contact = store.createContact({
+      firstName: 'Line\nBreak',
+      email: 'lb@cq.co.nz',
+      companyId: company.id,
+    });
+    store.createDeal({ title: 'Website build', contactId: contact.id, valueCents: 250000 });
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'crm-export-'));
+    const result = store.exportAll(dir, 'owner');
+
+    expect(result.directory).toBe(dir);
+    expect(result.files).toEqual([
+      'companies.csv',
+      'contacts.csv',
+      'deals.csv',
+      'activities.csv',
+      'notes.csv',
+      'tasks.csv',
+      'audit_log.csv',
+      'crm-export.json',
+    ]);
+    for (const f of result.files) {
+      expect(fs.existsSync(path.join(dir, f))).toBe(true);
+    }
+    expect(result.counts.companies).toBe(1);
+    expect(result.counts.contacts).toBe(1);
+    expect(result.counts.deals).toBe(1);
+    expect(result.counts.audit_log).toBeGreaterThanOrEqual(3);
+
+    // RFC 4180: embedded comma/quote/newline fields are quoted, quotes doubled, CRLF rows.
+    const companiesCsv = fs.readFileSync(path.join(dir, 'companies.csv'), 'utf8');
+    expect(companiesCsv).toContain('"Comma, Quote ""Co"""');
+    expect(companiesCsv.split('\r\n').length).toBeGreaterThanOrEqual(3); // header + row + trailing
+    const contactsCsv = fs.readFileSync(path.join(dir, 'contacts.csv'), 'utf8');
+    expect(contactsCsv).toContain('"Line\nBreak"');
+
+    // JSON payload round-trips and matches counts.
+    const json = JSON.parse(fs.readFileSync(path.join(dir, 'crm-export.json'), 'utf8'));
+    expect(json.companies).toHaveLength(1);
+    expect(json.counts).toEqual(result.counts);
+    expect(Array.isArray(json.stages)).toBe(true);
+    expect(typeof json.exportedAt).toBe('string');
+
+    // The export itself is audited (after the audit table snapshot was taken).
+    const log = store.getAuditLog(10, 'export');
+    expect(log.length).toBe(1);
+    expect(log[0].action).toBe('export');
+    expect(log[0].actor).toBe('owner');
+
+    fs.rmSync(dir, { recursive: true, force: true });
+    store.close();
+  });
+
+  test('in-memory database requires an explicit targetDir', () => {
+    const store = freshStore();
+    expect(() => store.exportAll()).toThrow(/targetDir is required/);
+    store.close();
+  });
+});

--- a/src/crm/store.ts
+++ b/src/crm/store.ts
@@ -24,6 +24,7 @@ import {
   CompanyInput,
   Contact,
   ContactInput,
+  CrmExportResult,
   DailyBrief,
   Deal,
   DealInput,
@@ -278,6 +279,12 @@ export class CrmStore {
           'SELECT * FROM audit_log WHERE entity_type = ? AND entity_id = ? ORDER BY id DESC LIMIT ?'
         )
         .all(entityType, entityId, cap)
+        .map(mapAudit);
+    }
+    if (entityType) {
+      return this.db
+        .prepare('SELECT * FROM audit_log WHERE entity_type = ? ORDER BY id DESC LIMIT ?')
+        .all(entityType, cap)
         .map(mapAudit);
     }
     return this.db
@@ -981,4 +988,84 @@ export class CrmStore {
       openPipelineValueCents: Number(openDeals.v),
     };
   }
+
+  // -------------------------------------------------------------------------
+  // Export (owner data portability: one CSV per table + combined JSON)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Export the entire CRM to `targetDir` (default: a timestamped folder next
+   * to the database file). Writes one RFC-4180 CSV per table plus a single
+   * `crm-export.json` containing everything, and audits the export itself.
+   */
+  exportAll(targetDir?: string, actor = 'owner'): CrmExportResult {
+    const exportedAt = nowIso();
+    let dir = targetDir;
+    if (!dir) {
+      if (this.databasePath === ':memory:') {
+        throw new Error('exportAll: targetDir is required for an in-memory database');
+      }
+      const stamp = exportedAt.replace(/[-:]/g, '').replace(/\..+$/, '').replace('T', '-');
+      dir = path.join(path.dirname(this.databasePath), `crm-export-${stamp}`);
+    }
+    fs.mkdirSync(dir, { recursive: true });
+
+    const files: string[] = [];
+    const counts: Record<string, number> = {};
+    const jsonPayload: Record<string, unknown> = {};
+
+    for (const table of EXPORT_TABLES) {
+      const stmt = this.db.prepare(`SELECT * FROM ${table} ORDER BY id`);
+      const columns: string[] = stmt.columns().map((c: any) => c.name as string);
+      const objects = stmt.all() as Array<Record<string, unknown>>;
+      counts[table] = objects.length;
+      jsonPayload[table] = objects;
+
+      const lines: string[] = [columns.map(csvEscape).join(',')];
+      for (const row of objects) {
+        lines.push(columns.map((c) => csvEscape(row[c])).join(','));
+      }
+      const fileName = `${table}.csv`;
+      fs.writeFileSync(path.join(dir, fileName), lines.join('\r\n') + '\r\n', 'utf8');
+      files.push(fileName);
+    }
+
+    jsonPayload.stages = this.getStages();
+    jsonPayload.exportedAt = exportedAt;
+    jsonPayload.counts = counts;
+    fs.writeFileSync(
+      path.join(dir, 'crm-export.json'),
+      JSON.stringify(jsonPayload, null, 2),
+      'utf8'
+    );
+    files.push('crm-export.json');
+
+    const result: CrmExportResult = { directory: dir, files, counts, exportedAt };
+    this.audit('crm_export', 'export', null, 'export', actor, null, {
+      directory: dir,
+      counts,
+    });
+    return result;
+  }
+}
+
+/** Tables included in a full export (audit_log included — it is the trust story). */
+const EXPORT_TABLES = [
+  'companies',
+  'contacts',
+  'deals',
+  'activities',
+  'notes',
+  'tasks',
+  'audit_log',
+] as const;
+
+/** RFC 4180 field escaping: quote when needed, double embedded quotes. */
+function csvEscape(value: unknown): string {
+  if (value == null) return '';
+  const s = String(value);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
 }

--- a/src/crm/types.ts
+++ b/src/crm/types.ts
@@ -129,9 +129,9 @@ export interface Task {
 export interface AuditEntry {
   id: number;
   toolName: string;
-  entityType: 'company' | 'contact' | 'deal' | 'activity' | 'note' | 'task' | 'settings';
+  entityType: 'company' | 'contact' | 'deal' | 'activity' | 'note' | 'task' | 'settings' | 'export';
   entityId: number | null;
-  action: 'create' | 'update' | 'delete' | 'complete' | 'advance';
+  action: 'create' | 'update' | 'delete' | 'complete' | 'advance' | 'export';
   actor: string;
   before: string | null;
   after: string | null;
@@ -220,4 +220,15 @@ export interface DailyBrief {
   recentActivities: Activity[];
   openDealCount: number;
   openPipelineValueCents: number;
+}
+
+/** Result of a full CRM data export (CSV per table + one combined JSON). */
+export interface CrmExportResult {
+  /** Absolute directory the export was written into. */
+  directory: string;
+  /** Files written, relative to `directory`. */
+  files: string[];
+  /** Row counts per exported table. */
+  counts: Record<string, number>;
+  exportedAt: string;
 }

--- a/widget/src/main/__tests__/crm-tools.test.ts
+++ b/widget/src/main/__tests__/crm-tools.test.ts
@@ -168,3 +168,28 @@ describe('CRM tools — end-to-end flow', () => {
     expect((found.result as any).count).toBe(1);
   });
 });
+
+describe('crm_export', () => {
+  test('exports CSVs + JSON to an explicit directory', async () => {
+    await call('crm_create_company', { name: 'Export Co', domain: 'export.co.nz' });
+    const target = path.join(tmpDir, 'out');
+    const res = await call('crm_export', { targetDir: target });
+    expect(res.success).toBe(true);
+    const result = res.result as any;
+    expect(result.directory).toBe(target);
+    expect(result.counts.companies).toBe(1);
+    for (const f of ['companies.csv', 'audit_log.csv', 'crm-export.json']) {
+      expect(fs.existsSync(path.join(target, f))).toBe(true);
+    }
+  });
+
+  test('defaults to a timestamped folder beside the database', async () => {
+    await call('crm_create_company', { name: 'Default Dir Co' });
+    const res = await call('crm_export', {});
+    expect(res.success).toBe(true);
+    const dir = (res.result as any).directory as string;
+    expect(dir.startsWith(tmpDir)).toBe(true);
+    expect(path.basename(dir)).toMatch(/^crm-export-\d{8}-\d{6}$/);
+    expect(fs.existsSync(path.join(dir, 'crm-export.json'))).toBe(true);
+  });
+});

--- a/widget/src/main/tools/crm.ts
+++ b/widget/src/main/tools/crm.ts
@@ -460,6 +460,25 @@ export const crmAuditLogDef: ToolDefinition = {
   },
 };
 
+export const crmExportDef: ToolDefinition = {
+  name: 'crm_export',
+  description:
+    'Export the entire CRM to files the owner can open anywhere: one CSV per table ' +
+    '(companies, contacts, deals, activities, notes, tasks, audit log) plus a combined ' +
+    'crm-export.json. Defaults to a timestamped folder next to the database.',
+  category: 'crm',
+  parameters: {
+    type: 'object',
+    properties: {
+      targetDir: {
+        type: 'string',
+        description: 'Optional absolute directory to write into (created if missing)',
+      },
+    },
+    required: [],
+  },
+};
+
 // ============= HANDLERS =============
 
 export const crmToolHandlers: Record<string, ToolHandler> = {
@@ -648,6 +667,10 @@ export const crmToolHandlers: Record<string, ToolHandler> = {
     );
     return { count: entries.length, entries };
   }),
+
+  crm_export: wrap('crm_export', (a) =>
+    getCrmStore().exportAll(asOptStr(a.targetDir) || undefined, 'owner')
+  ),
 };
 
 // ============= EXPORTS =============
@@ -673,4 +696,5 @@ export const crmToolDefs: ToolDefinition[] = [
   crmGetStagesDef,
   crmRenameStageDef,
   crmAuditLogDef,
+  crmExportDef,
 ];


### PR DESCRIPTION
Follow-up to #72 (CRM Phase 1). Adds the missing data-portability piece.

## What
- `CrmStore.exportAll(targetDir?, actor)` — writes one RFC-4180 CSV per table (companies, contacts, deals, activities, notes, tasks, **audit_log**) plus a combined `crm-export.json` (all rows + stages + counts + timestamp). Defaults to a timestamped folder beside the SQLite file; export action is itself appended to the audit log.
- New `crm_export` tool (21st `crm_*` tool) registered in the widget adapter.
- Fix: `getAuditLog(limit, entityType)` with no entityId previously ignored the type filter — now supported.

## Verification
- Root: `tsc --noEmit` clean, jest **95/95** (2 new export tests: RFC-4180 escaping incl. embedded commas/quotes/newlines, CRLF rows, JSON round-trip, export audited, in-memory guard)
- Widget: crm-tools **10/10** (explicit dir + default timestamped dir), `electron-vite build` green