### PR TITLE
fix(release): first-run readiness — Windows installer pipeline, telemetry opt-in, broken URLs

### DIFF
--- a/.github/workflows/preflight-and-build-release.yml
+++ b/.github/workflows/preflight-and-build-release.yml
@@ -5,9 +5,14 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   preflight-and-build:
-    runs-on: ubuntu-latest
+    # HomeBot ships a Windows NSIS installer — this must run on Windows.
+    # Building the win/nsis target on ubuntu-latest cannot produce a usable HomeBot-Setup.exe.
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,3 +30,21 @@ jobs:
 
       - name: Build and package widget
         run: npm run dist --prefix widget
+
+      - name: Upload installer to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            widget/dist-electron/*.exe
+            widget/dist-electron/*.exe.blockmap
+            widget/dist-electron/latest.yml
+
+      - name: Keep installer as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: homebot-windows-installer
+          path: |
+            widget/dist-electron/*.exe
+            widget/dist-electron/latest.yml
+          retention-days: 30

--- a/DEVELOPER_BUILD_GUIDE.md
+++ b/DEVELOPER_BUILD_GUIDE.md
@@ -46,8 +46,8 @@ A comprehensive guide for developers setting up HomeBot for local development, t
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/kingithegreat/HomeBot.git
-cd HomeBot
+git clone https://github.com/kingithegreat/Sadie.git
+cd Sadie
 ```
 
 ### 2. Install Dependencies

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ On first launch, the setup wizard will:
 ### Option B — Developer Setup
 
 ```bash
-git clone https://github.com/kingithegreat/HomeBot.git
-cd HomeBot/widget
+git clone https://github.com/kingithegreat/Sadie.git
+cd Sadie/widget
 npm install
 npm run dev
 ```

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -151,7 +151,7 @@ git push origin v<X.Y.Z>
 
 ### 5. GitHub Release
 
-1. Go to [Releases](https://github.com/kingithegreat/HomeBot/releases).
+1. Go to [Releases](https://github.com/kingithegreat/Sadie/releases).
 2. Click **Draft a new release**.
 3. Select the tag `v<X.Y.Z>`.
 4. Title: `v<X.Y.Z> — <summary>`.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -66,8 +66,8 @@ That's it — no terminal, no manual model pulls, no Docker. Everything below is
 ## Step 1 — Clone the Repository
 
 ```bash
-git clone https://github.com/kingithegreat/HomeBot.git
-cd HomeBot
+git clone https://github.com/kingithegreat/Sadie.git
+cd Sadie
 ```
 
 ---

--- a/widget/package.json
+++ b/widget/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kingithegreat/HomeBot.git"
+    "url": "https://github.com/kingithegreat/Sadie.git"
   },
   "scripts": {
     "start": "node -e \"delete process.env.ELECTRON_RUN_AS_NODE; require('child_process').execSync('electron .', {stdio:'inherit',env:process.env})\"",

--- a/widget/src/main/config-manager.ts
+++ b/widget/src/main/config-manager.ts
@@ -159,7 +159,7 @@ export const DEFAULT_SETTINGS: Settings = {
 
   // onboarding defaults
   firstRun: true,
-  telemetryEnabled: true, // REQUIRED: telemetry is anonymous and always enabled
+  telemetryEnabled: false, // opt-in only: enabled solely by explicit user consent (NZ Privacy Act 2020, IPP 3)
 
   // sensible safe defaults: most dangerous tools are disabled until user enables
   permissions: {

--- a/widget/src/renderer/__tests__/first-run-modal.test.tsx
+++ b/widget/src/renderer/__tests__/first-run-modal.test.tsx
@@ -195,7 +195,7 @@ describe('FirstRunModal — Get Started (final step)', () => {
     expect(onSave.mock.calls[0][0]).toMatchObject({ firstRun: false });
   });
 
-  test('calls onSave with telemetryEnabled: true', async () => {
+  test('telemetry is off by default and no consent timestamp is stamped', async () => {
     const onSave = jest.fn();
     render(
       <FirstRunModal open={true} settings={baseSettings} onSave={onSave} onClose={jest.fn()} />
@@ -210,7 +210,30 @@ describe('FirstRunModal — Get Started (final step)', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Get Started'));
     });
+    expect(onSave.mock.calls[0][0]).toMatchObject({ telemetryEnabled: false });
+    expect(onSave.mock.calls[0][0].telemetryConsentTimestamp).toBeUndefined();
+  });
+
+  test('checking the consent box enables telemetry and stamps consent', async () => {
+    const onSave = jest.fn();
+    render(
+      <FirstRunModal open={true} settings={baseSettings} onSave={onSave} onClose={jest.fn()} />
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Local (Ollama)'));
+    });
+    await act(async () => { await new Promise(r => setTimeout(r, 10)); });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Next'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('checkbox'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Get Started'));
+    });
     expect(onSave.mock.calls[0][0]).toMatchObject({ telemetryEnabled: true });
+    expect(typeof onSave.mock.calls[0][0].telemetryConsentTimestamp).toBe('string');
   });
 
   test('calls onClose after Get Started', async () => {
@@ -292,7 +315,8 @@ describe('FirstRunModal — Skip setup button', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Skip setup'));
     });
-    expect(onSave.mock.calls[0][0]).toMatchObject({ firstRun: false, telemetryEnabled: true });
+    expect(onSave.mock.calls[0][0]).toMatchObject({ firstRun: false, telemetryEnabled: false });
+    expect(onSave.mock.calls[0][0].telemetryConsentTimestamp).toBeUndefined();
   });
 
   test('calls onClose after Skip setup', async () => {

--- a/widget/src/renderer/components/FirstRunModal.tsx
+++ b/widget/src/renderer/components/FirstRunModal.tsx
@@ -92,6 +92,7 @@ export default function FirstRunModal({
 }) {
   const [draft, setDraft] = useState<Settings>(settings);
   const [step, setStep] = useState<Step>('welcome');
+  const [telemetryConsent, setTelemetryConsent] = useState(false);
   const [setupPath, setSetupPath] = useState<SetupPath>(null);
 
   // Local path state
@@ -328,7 +329,8 @@ export default function FirstRunModal({
   };
 
   const handleFinish = async () => {
-    const payload: any = { ...draft, firstRun: false, telemetryEnabled: true, telemetryConsentTimestamp: new Date().toISOString() };
+    const payload: any = { ...draft, firstRun: false, telemetryEnabled: telemetryConsent };
+    if (telemetryConsent) payload.telemetryConsentTimestamp = new Date().toISOString();
 
     if (setupPath === 'cloud' && cloudApiKey.trim()) {
       const apiUrl = PROVIDER_URLS[cloudProvider] || '';
@@ -353,7 +355,7 @@ export default function FirstRunModal({
   };
 
   const handleSkip = async () => {
-    const payload = { ...draft, firstRun: false, telemetryEnabled: true, telemetryConsentTimestamp: new Date().toISOString() } as any;
+    const payload = { ...draft, firstRun: false, telemetryEnabled: false } as any;
     try { await (window as any).electron.saveSettings?.(payload); } catch (e) { console.warn('FirstRun skip save failed:', e); }
     onSave(payload);
     onClose();
@@ -611,6 +613,18 @@ export default function FirstRunModal({
                 <span className="wizard-suggestion-chip">Summarize my clipboard</span>
                 <span className="wizard-suggestion-chip">What's in the news?</span>
               </div>
+              <label className="wizard-telemetry-consent">
+                <input
+                  type="checkbox"
+                  checked={telemetryConsent}
+                  onChange={(e) => setTelemetryConsent(e.target.checked)}
+                />
+                <span>
+                  Help improve HomeBot by sharing anonymous usage statistics (feature counts and
+                  error rates only). No personal data or conversation content is ever collected.
+                  Off by default — you can change this any time in Settings.
+                </span>
+              </label>
             </div>
           )}
         </div>

--- a/widget/src/renderer/e2e/first-run.e2e.spec.ts
+++ b/widget/src/renderer/e2e/first-run.e2e.spec.ts
@@ -12,7 +12,7 @@ function makeTempProfile() {
   return base;
 }
 
-async function completeFirstRunWizard(page: any) {
+async function completeFirstRunWizard(page: any, opts: { optInTelemetry?: boolean } = {}) {
   await expect(page.getByText('Welcome to HomeBot')).toBeVisible({ timeout: 15000 });
   const modal = page.locator('.first-run-modal');
   // Choose Local path
@@ -21,6 +21,9 @@ async function completeFirstRunWizard(page: any) {
   // Advance to done
   await modal.getByRole('button', { name: /Next|Continue anyway/i }).click();
   await expect(page.getByText("You're all set!")).toBeVisible({ timeout: 5000 });
+  if (opts.optInTelemetry) {
+    await modal.locator('.wizard-telemetry-consent input[type="checkbox"]').check();
+  }
   await modal.getByRole('button', { name: /Get Started/i }).click();
 }
 
@@ -45,7 +48,7 @@ test.describe('First-run onboarding and config persistence', () => {
     await expect(fs.existsSync(configPath)).toBeTruthy();
     const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     expect(config.firstRun).toBe(false);
-    expect(config.telemetryEnabled).toBe(true);
+    expect(config.telemetryEnabled).toBe(false);
 
     await app.close();
   });
@@ -81,33 +84,17 @@ test.describe('First-run onboarding and config persistence', () => {
     await app.close();
   });
 
-  test('telemetry is required and consent is recorded on finish', async () => {
+  test('telemetry is opt-in: checking consent enables it and records a timestamp', async () => {
     const tmp = makeTempProfile();
     const { app, page } = await launchElectronApp({ HOMEBOT_E2E: '1', NODE_ENV: 'test' }, tmp);
     await waitForAppReady(page);
 
-    await completeFirstRunWizard(page);
+    await completeFirstRunWizard(page, { optInTelemetry: true });
 
     const configPath = path.join(tmp, 'config', 'user-settings.json');
     const waitForConfig = async () => {
       const start = Date.now();
-      while (Date.now() - start < 5000) {
-        if (fs.existsSync(configPath)) {
-          const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-          if (cfg.telemetryEnabled === true) return cfg;
-        }
-        await new Promise(r => setTimeout(r, 100));
-      }
-      try {
-        await page.evaluate(async () => {
-          const s = await (window as any).electron.getSettings();
-          s.telemetryEnabled = true;
-          s.telemetryConsentTimestamp = new Date().toISOString();
-          await (window as any).electron.saveSettings(s);
-        });
-      } catch (err) {}
-      const start2 = Date.now();
-      while (Date.now() - start2 < 5000) {
+      while (Date.now() - start < 10000) {
         if (fs.existsSync(configPath)) {
           const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
           if (cfg.telemetryEnabled === true) return cfg;
@@ -116,11 +103,12 @@ test.describe('First-run onboarding and config persistence', () => {
       }
       const runtime = await page.evaluate(async () => await (window as any).electron.getSettings());
       if (runtime && runtime.telemetryEnabled === true) return runtime;
-      throw new Error('Timed out waiting for config telemetryEnabled=true after forcing save');
+      throw new Error('Timed out waiting for opted-in telemetryEnabled=true');
     };
 
     const config = await waitForConfig();
     expect(config.telemetryEnabled).toBe(true);
+    expect(typeof config.telemetryConsentTimestamp).toBe('string');
 
     const consentLog = path.join(tmp, 'logs', 'telemetry-consent.log');
     if (fs.existsSync(consentLog)) {

--- a/widget/src/renderer/styles/chatgpt-theme.css
+++ b/widget/src/renderer/styles/chatgpt-theme.css
@@ -4415,6 +4415,18 @@ body {
   border: 1px solid var(--border-light, #333);
 }
 
+.wizard-telemetry-consent {
+  display: flex; align-items: flex-start; gap: 10px;
+  margin-top: 20px; padding: 12px 14px; border-radius: 10px;
+  background: var(--bg-secondary, #16213e);
+  border: 1px solid var(--border-light, #333);
+  font-size: 12.5px; line-height: 1.5; text-align: left;
+  color: var(--text-secondary); cursor: pointer;
+}
+.wizard-telemetry-consent input[type="checkbox"] {
+  margin-top: 2px; flex-shrink: 0; cursor: pointer;
+}
+
 /* Collapsible settings section toggle */
 .sp-section-toggle {
   display: flex; align-items: center; gap: 10px; width: 100%;


### PR DESCRIPTION
Closes out the July first-run readiness audit — the three blockers that stop a real user from installing HomeBot.

## Release pipeline (the big one)
- `preflight-and-build-release.yml` now runs on **windows-latest** — the NSIS target cannot produce a usable `HomeBot-Setup.exe` on ubuntu.
- Uploads the installer + `latest.yml` + blockmap to the GitHub release automatically (`softprops/action-gh-release@v2`), plus a 30-day workflow artifact for `workflow_dispatch` runs.
- Output paths point at `widget/dist-electron` — the **actual** electron-builder output dir (the July patch used `widget/release`, which would have silently uploaded nothing).

## Telemetry opt-in (NZ Privacy Act 2020, IPP 3)
- `config-manager.ts` default: `telemetryEnabled: false`.
- Consent checkbox on the wizard done step; timestamp written **only** on explicit opt-in.
- Skip path never grants consent.
- Unit tests + e2e spec rewritten to assert opt-in behaviour (including a new opted-in path test).
- Settings panel enable flow untouched — that is legitimate user-initiated opt-in.

## Broken URLs
- `kingithegreat/HomeBot` → `kingithegreat/Sadie` across README, setup-guide, DEVELOPER_BUILD_GUIDE, RELEASE_PROCESS, and `widget/package.json` repository field. `cd HomeBot` paths fixed.

## Not verified in container
`npm ci` fails here (onnxruntime-node → Nuget blocked), so Jest was not run. All four edited TS/TSX files pass esbuild syntax checks and the workflow YAML validates. CI will run the real suite.